### PR TITLE
查询前先攒上 cookie：没带 cookie 的请求会被 Apple 拦下（v0.3.2）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "apw-app"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "apw-core",
  "reqwest 0.12.28",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "apw-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "dirs",
  "rand 0.9.5",
@@ -603,8 +603,27 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -949,6 +968,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -2187,6 +2215,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3031,6 +3065,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3254,6 +3304,8 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cookie",
+ "cookie_store",
  "futures-core",
  "h2",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/apw-core", "src-tauri"]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.90"
 license = "GPL-3.0-or-later"
@@ -11,7 +11,7 @@ repository = "https://github.com/ENCHIGO/apple-pickup-watcher"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "http2"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip", "http2", "cookies"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 支持 **iPhone、iPad、Mac、Apple Watch** 四个品类，七个地区：中国大陆、中国香港、
 中国台湾、日本、Singapore、Australia、Malaysia。
 
-跨平台桌面应用，macOS / Windows / Linux。Rust + Tauri，v0.3.1。
+跨平台桌面应用，macOS / Windows / Linux。Rust + Tauri，v0.3.2。
 
 **English** — Apple Pickup Watcher monitors in-store pickup availability at Apple Retail
 Stores and alerts you the moment a specific model becomes available at the store you
@@ -397,6 +397,27 @@ curl -sS -o /dev/null -w 'HTTP %{http_code}  size=%{size_download}\n' \
 541 不是标准 HTTP 状态码，是 Apple 边缘节点自定义的拦截响应。看到它基本可以确定请求被
 挡下了，而不是「没有库存」。降低查询频率、更换 User-Agent、加重试都无法绕过 —— 问题不在
 频率或伪装，在于那个接口本身已经不在了。
+
+### 程序报「请求被 Apple 拦截：HTTP 541」，可浏览器打开官网一切正常？
+
+**先别去调查询间隔，那多半没用。** 这个问题（[issue #3](https://github.com/ENCHIGO/apple-pickup-watcher/issues/3)）
+的报告者把间隔从 5 秒改到 120 秒，照样被拦 —— 一个门店两分钟一次请求，换算下来每秒 0.025 次，
+没有任何以流量为判准的风控会对这个数字有反应。
+
+真正的原因是**没带 cookie**。报告者在同一个浏览器里做了十轮成对对照，唯一的变量就是带不带 cookie：
+
+```
+带 cookie   10/10 全部 200
+不带 cookie  8/10  返回 541
+```
+
+而这件事**只在被风控盯上的网络上才看得出来**：在没被盯上的网络里，带不带 cookie 都是 200，
+怎么对照都测不出差别。我们自己就因此误判过一次 —— 拿「本机两种都正常」当反证，把正确的
+假设枪毙了，转头去追 TLS 指纹，绕了一大圈。**在复现不了问题的环境里得到的阴性结果，
+什么都不能证明。**
+
+v0.3.2 起客户端会先取一次购买页把 cookie 攒上再查询，被拦时丢掉重攒。如果你装的是更早的
+版本，升级即可；升级后仍被拦的话，请开一个 issue 并附上日志。
 
 ### 现在还能用的接口是哪个？
 

--- a/crates/apw-core/src/apple.rs
+++ b/crates/apw-core/src/apple.rs
@@ -3,6 +3,7 @@
 //! 这里只做「发请求 + 解析响应 + 分类错误」三件事，不含调度或界面逻辑，
 //! 因此可以脱离应用单独测试。
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -114,15 +115,26 @@ pub struct AppleClient {
     config: ClientConfig,
     /// 上一次出站请求的时刻，用于全局限速。
     last_sent: Arc<Mutex<Option<Instant>>>,
+    /// Cookie 罐。
+    ///
+    /// 自己持有一份而不是用 `cookie_store(true)` 那个隐藏的内部罐，是为了能
+    /// 查得到里面到底有没有东西 —— 契约测试要断言「暖场之后真的攒到了 cookie」。
+    /// 一个「以为自己在带 cookie、其实罐是空的」的客户端，功能上和现在一模一样，
+    /// 没有任何迹象。
+    jar: Arc<reqwest::cookie::Jar>,
+    /// 已经暖过场的地区 locale。
+    warmed: Arc<Mutex<HashSet<String>>>,
 }
 
 impl AppleClient {
     pub fn new(config: ClientConfig) -> Result<Self, ApiError> {
+        let jar = Arc::new(reqwest::cookie::Jar::default());
         let http = reqwest::Client::builder()
             .timeout(config.timeout)
             .connect_timeout(Duration::from_secs(5))
             .pool_idle_timeout(Duration::from_secs(90))
             .pool_max_idle_per_host(8)
+            .cookie_provider(jar.clone())
             .build()
             .map_err(|e| ApiError::Transport(format!("构造 HTTP 客户端失败：{e}")))?;
 
@@ -130,7 +142,72 @@ impl AppleClient {
             http,
             config,
             last_sent: Arc::new(Mutex::new(None)),
+            jar,
+            warmed: Arc::new(Mutex::new(HashSet::new())),
         })
+    }
+
+    /// 确保这个地区的 cookie 已经攒上了。
+    ///
+    /// # 为什么非做不可
+    ///
+    /// Apple 的边缘节点会对**没带 cookie** 的取货查询下手。issue #3 的报告者在
+    /// 同一个浏览器里做了十轮成对对照，只差带不带 cookie：
+    ///
+    /// ```text
+    /// 带 cookie  10/10 全部 200
+    /// 不带 cookie 8/10  返回 541
+    /// ```
+    ///
+    /// 而这件事**只在受审查的网络上才看得出来**：在没被盯上的网络里，带不带
+    /// cookie 都是 200，怎么对照都测不出差别。所以别拿「我这里两种都正常」
+    /// 当反证 —— 这个假设正是这么被误杀过一次的。
+    ///
+    /// 一次成功的查询本身也会带回 cookie（那个端点自己就发 8 个 Set-Cookie），
+    /// 所以在正常网络上这次暖场之后就再也不会发生。但受审查的网络上第一次查询
+    /// 就会被拦，攒不到 cookie，只能先主动取一次页面。
+    ///
+    /// **失败不影响查询**：暖场取不到页面时什么都不做，让真正的查询照常发出去。
+    /// 让一次辅助请求的失败去决定库存判定，正是这个项目最不该有的东西。
+    async fn ensure_warm(&self, region: &Region) {
+        if self.warmed.lock().await.contains(region.locale) {
+            return;
+        }
+
+        self.throttle().await;
+        let ok = self
+            .http
+            .get(region.bag_url())
+            .header(reqwest::header::USER_AGENT, &self.config.user_agent)
+            .header(
+                reqwest::header::ACCEPT,
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            )
+            .header(reqwest::header::ACCEPT_LANGUAGE, region.accept_language())
+            .send()
+            .await
+            .is_ok_and(|r| r.status().is_success());
+
+        if ok {
+            self.warmed.lock().await.insert(region.locale.to_string());
+        }
+    }
+
+    /// 忘掉某地区的暖场标记，下一轮会重新攒 cookie。
+    ///
+    /// 被拦截时调用。cookie 会过期，也会被边缘节点作废；一直拿着一份不再被认可
+    /// 的 cookie 反复重试，只会一直被拦。
+    async fn forget_warm(&self, region: &Region) {
+        self.warmed.lock().await.remove(region.locale);
+    }
+
+    /// 这个地区当前攒到的 cookie，没有则返回 `None`。契约测试用。
+    pub fn cookies_for(&self, region: &Region) -> Option<String> {
+        use reqwest::cookie::CookieStore;
+        let url = region.bag_url().parse().ok()?;
+        self.jar
+            .cookies(&url)
+            .and_then(|v| v.to_str().ok().map(str::to_owned))
     }
 
     /// 查询 `store_number` 门店中 `parts` 各型号的可取货状态。
@@ -159,9 +236,21 @@ impl AppleClient {
             query.push((format!("parts.{i}"), part.clone()));
         }
 
-        let body = self
-            .get(&region.pickup_message_url(), &query, region)
-            .await?;
+        // 先把 cookie 攒上再查。见 ensure_warm 的文档：没带 cookie 的查询会被
+        // Apple 的边缘节点拦下，而且只在受审查的网络上才拦。
+        self.ensure_warm(region).await;
+
+        let body = match self.get(&region.pickup_message_url(), &query, region).await {
+            Ok(body) => body,
+            Err(err) => {
+                if matches!(err, ApiError::Blocked(_)) {
+                    // 带着 cookie 还被拦，多半是它已经过期或被作废了。丢掉标记，
+                    // 下一轮重新攒一份，而不是抱着一份不再被认可的 cookie 死磕。
+                    self.forget_warm(region).await;
+                }
+                return Err(err);
+            }
+        };
         parse_pickup_message(&body, store_number)
     }
 

--- a/crates/apw-core/tests/live.rs
+++ b/crates/apw-core/tests/live.rs
@@ -118,6 +118,46 @@ async fn 必须以http2跟apple说话() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn 查询时必须带上cookie() {
+    // Apple 的边缘节点会对没带 cookie 的取货查询下手。issue #3 的报告者在同一个
+    // 浏览器里做了十轮成对对照，唯一的变量就是带不带 cookie：
+    //
+    //     带 cookie   10/10 全部 200
+    //     不带 cookie  8/10  返回 541
+    //
+    // 要命的是这件事**只在受审查的网络上才看得出来**：在没被盯上的网络里两种
+    // 都是 200，怎么对照都测不出差别 —— 这个假设正是这么被误杀过一次的。
+    //
+    // 所以这条测试不去验「带了 cookie 就不会被拦」（在这里验不出来），只钉住
+    // 一件能验的事：**罐子里真的有东西**。一个「以为自己在带 cookie、其实罐是
+    // 空的」的客户端，功能上和现在一模一样，不会有任何迹象。
+    let client = client();
+    let region = region_by_locale("zh_TW").expect("地区表里应当有中国台湾");
+
+    assert!(
+        client.cookies_for(region).is_none(),
+        "还没发过任何请求，cookie 罐就该是空的"
+    );
+
+    let parts = vec!["MDV94TA/A".to_string()];
+    client
+        .pickup_message(region, "R713", &parts)
+        .await
+        .unwrap_or_else(|e| panic!("查询失败：{e}"));
+
+    let cookies = client
+        .cookies_for(region)
+        .expect("查过一次之后，cookie 罐不该还是空的 —— 暖场或响应里的 Set-Cookie 没生效");
+
+    println!("攒到的 cookie：{cookies}");
+    // Apple 的 shop 会话 cookie。名字变了要来更新这里，而不是删掉断言。
+    assert!(
+        cookies.contains("dssid2") || cookies.contains("as_dc"),
+        "攒到的 cookie 里没有 shop 的会话项：{cookies}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn 无效零件号不会被判成无货() {
     // 本项目最关键的不变量在真实接口上也必须成立。
     let client = client();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-pickup-watcher",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Apple Pickup Watcher",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "io.github.enchigo.apple-pickup-watcher",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
#3 的真正原因，有决定性证据。

## 证据

报告者在**同一个浏览器**里做了十轮成对对照，唯一的变量就是带不带 cookie：

```
#1  帶 Cookie → 200   不帶 Cookie → 541
#2  帶 Cookie → 200   不帶 Cookie → 541
#3  帶 Cookie → 200   不帶 Cookie → 541
#4  帶 Cookie → 200   不帶 Cookie → 200
#5  帶 Cookie → 200   不帶 Cookie → 200
#6  帶 Cookie → 200   不帶 Cookie → 541
…#10 同上
```

**带 cookie 10/10 通过，不带 cookie 8/10 被拦。** 同一套 TLS 指纹、同样的标头、同一条网络 —— 所以不是指纹的问题，我们之前那个方向是错的。

## 这个假设被误杀过一次，值得记一笔

我先前在**自己的浏览器**上做过同样的对照，两种都是 200，就据此把 cookie 假设枪毙了，转去追 TLS 指纹 —— 期间还测了 `native-tls`、调研了 WebView 方案的 CORS 限制、分析了 BoringSSL 伪装的取舍，全是为错方向做的功。

问题在于：**我的网络不受审查，在那里做这个对照必然测不出差别。** 在一个复现不了问题的环境里得到阴性结果，什么都不能证明。这条已经写进 `ensure_warm` 的文档注释和契约测试的注释里，免得下一个人重犯。

## 做法

- 客户端持有**自己的** `Arc<Jar>`，而不是 `cookie_store(true)` 那个隐藏的内部罐 —— 因为要能查得到罐里到底有没有东西。一个「以为自己在带 cookie、其实罐是空的」客户端，功能上和现在一模一样，不会有任何迹象。
- 查询前按地区暖场一次（取 `/shop/bag`，那里给 8 个 cookie）。
- 被拦截时丢掉暖场标记，下一轮重攒 —— cookie 会过期也会被作废，抱着一份不再被认可的死磕只会一直被拦。
- **暖场失败绝不影响查询**：让一次辅助请求的成败去左右库存判定，正是这个项目最不该有的东西。

顺带发现 `pickup-message` 端点自己就返回 8 个 `Set-Cookie`，所以正常网络上暖场一次之后就再也不会触发。

## 契约测试

新增的那条不去验「带了 cookie 就不会被拦」（在我们的网络上验不出来），只钉住一件**能验**的事：罐子里真的有东西。实测拿到 `dssid2`、`as_dc`、`as_pcts` 等 shop 会话项。

## 检查

`cargo fmt` / `clippy -D warnings` / 13 组离线测试 / `tsc` 全过；8 个真实网络契约测试全绿。

README 补了一条 FAQ（「程序报 541 但浏览器正常」），版本号三处加 README 一起改到 **0.3.2**。

https://claude.ai/code/session_01U8sJtKbXAYVq3rg1D4h7Ki