### PR TITLE
发布 v0.4.0：iPhone 18 Pro 与 Duo 支持

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "apw-app"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "apw-core",
  "reqwest 0.12.28",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "apw-core"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "dirs",
  "rand 0.9.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "apw-app"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "apw-core",
  "reqwest 0.12.28",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "apw-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "dirs",
  "rand 0.9.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/apw-core", "src-tauri"]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.90"
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/apw-core", "src-tauri"]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 rust-version = "1.90"
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 支持 **iPhone、iPad、Mac、Apple Watch** 四个品类，七个地区：中国大陆、中国香港、
 中国台湾、日本、Singapore、Australia、Malaysia。
 
-跨平台桌面应用，macOS / Windows / Linux。Rust + Tauri，v0.3.4。
+跨平台桌面应用，macOS / Windows / Linux。Rust + Tauri，v0.4.0。
 
 **English** — Apple Pickup Watcher monitors in-store pickup availability at Apple Retail
 Stores and alerts you the moment a specific model becomes available at the store you

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 支持 **iPhone、iPad、Mac、Apple Watch** 四个品类，七个地区：中国大陆、中国香港、
 中国台湾、日本、Singapore、Australia、Malaysia。
 
-跨平台桌面应用，macOS / Windows / Linux。Rust + Tauri，v0.3.3。
+跨平台桌面应用，macOS / Windows / Linux。Rust + Tauri，v0.3.4。
 
 **English** — Apple Pickup Watcher monitors in-store pickup availability at Apple Retail
 Stores and alerts you the moment a specific model becomes available at the store you

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-pickup-watcher",
   "private": true,
-  "version": "0.3.4",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-pickup-watcher",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Apple Pickup Watcher",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "identifier": "io.github.enchigo.apple-pickup-watcher",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Apple Pickup Watcher",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "identifier": "io.github.enchigo.apple-pickup-watcher",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
为已合入的 iPhone 18 Pro、iPhone 18 Pro Max 和 iPhone Duo 适配发布 v0.4.0 安装包及应用内更新。

将 Cargo 工作区、两个本地 crate 的锁文件版本、package.json、Tauri 配置及 README 统一更新至 0.4.0。已核对第三方依赖锁定记录完全一致。

验证：Cargo metadata 确认两个本地 crate 均为 0.4.0；cargo check --workspace --offline --locked、cargo fmt、pnpm build、git diff --check 通过。新机适配在 PR #12 中已经过完整测试和七地区官网数据、取货接口核对。

合并并通过检查后打 v0.4.0 标签，构建 macOS Apple Silicon、macOS Intel、Windows x64 和 Linux x64。Release 保留草稿至资产、更新签名和更新清单核验完成，再公开发布。

Refs #7, #12
