### PR TITLE
添加 agent CLI 与 skill，精简 README

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,58 @@
+name: CLI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cli-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cli:
+    name: CLI (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-latest
+            target: aarch64-apple-darwin
+            binary: apw
+          - runner: macos-15-intel
+            target: x86_64-apple-darwin
+            binary: apw
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            binary: apw
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary: apw.exe
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      # No GTK, WebKit or ALSA installation: prove the CLI is headless.
+      - run: cargo fmt --all --check
+      - run: cargo test --locked -p apw-cli
+      - run: cargo test --locked -p apw-core --no-default-features
+      - run: cargo clippy --locked -p apw-cli --all-targets -- -D warnings
+      - run: cargo build --release --locked -p apw-cli --target ${{ matrix.target }}
+      - run: python3 scripts/package-cli.py --binary target/${{ matrix.target }}/release/${{ matrix.binary }} --target ${{ matrix.target }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: apw-cli-${{ matrix.target }}
+          path: target/cli-dist/*
+          if-no-files-found: error

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -52,10 +52,10 @@ jobs:
       - run: cargo test --locked -p apw-cli
       - run: cargo test --locked -p apw-core --no-default-features
       - run: cargo clippy --locked -p apw-cli --all-targets -- -D warnings
-      - run: python3 -m unittest discover -s scripts -p 'test_package_cli.py'
+      - run: python -m unittest discover -s scripts -p 'test_package_cli.py'
       - run: cargo build --release --locked -p apw-cli --target ${{ matrix.target }}
       - run: target/${{ matrix.target }}/release/${{ matrix.binary }} schema > target/cli-schema.json
-      - run: python3 scripts/package-cli.py --binary target/${{ matrix.target }}/release/${{ matrix.binary }} --target ${{ matrix.target }}
+      - run: python scripts/package-cli.py --binary target/${{ matrix.target }}/release/${{ matrix.binary }} --target ${{ matrix.target }}
       - uses: actions/upload-artifact@v7
         with:
           name: apw-cli-${{ matrix.target }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: cli-${{ github.event_name }}-${{ github.ref }}
+  group: cli-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -44,12 +44,17 @@ jobs:
           components: rustfmt, clippy
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       # No GTK, WebKit or ALSA installation: prove the CLI is headless.
       - run: cargo fmt --all --check
       - run: cargo test --locked -p apw-cli
       - run: cargo test --locked -p apw-core --no-default-features
       - run: cargo clippy --locked -p apw-cli --all-targets -- -D warnings
+      - run: python3 -m unittest discover -s scripts -p 'test_package_cli.py'
       - run: cargo build --release --locked -p apw-cli --target ${{ matrix.target }}
+      - run: target/${{ matrix.target }}/release/${{ matrix.binary }} schema > target/cli-schema.json
       - run: python3 scripts/package-cli.py --binary target/${{ matrix.target }}/release/${{ matrix.binary }} --target ${{ matrix.target }}
       - uses: actions/upload-artifact@v7
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Apple Pickup Watcher 是 Rust + Tauri v2 + React/TypeScript 桌面应用。
 ## Structure
 
 - `crates/apw-core/`：库存类型、Apple 客户端、商品目录、监控调度、通知与配置持久化。
+- `crates/apw-cli/`：独立 `apw` CLI，JSON/NDJSON 接口；`skills/apple-pickup-watcher/`：配套 agent skill。
 - `src-tauri/`：桌面装配、IPC、托盘、系统通知和购物袋打开。
 - `src/`：React 界面与前端状态；`tests/`：前端交互及异步状态回归。
 - `crates/apw-core/data/`：离线快照及其生成脚本。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +132,19 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-updater",
+ "tokio",
+]
+
+[[package]]
+name = "apw-cli"
+version = "0.4.0"
+dependencies = [
+ "apw-core",
+ "clap",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -560,6 +623,52 @@ dependencies = [
  "serde",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1992,6 +2101,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,6 +2850,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
@@ -4615,6 +4736,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -4996,6 +5118,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["crates/apw-core", "src-tauri"]
+members = ["crates/apw-core", "crates/apw-cli", "src-tauri"]
 
 [workspace.package]
 version = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -1,462 +1,95 @@
-# Apple Pickup Watcher · 苹果直营店库存监控与到货提醒
+# Apple Pickup Watcher
 
-**免费开源的 Apple Store 到店取货库存监控工具**。选择 Apple 直营店和商品型号，
-在查询确认有货时接收系统通知、提示音或可选的 Bark 手机推送。
-适合个人关注 **iPhone、iPad、Mac、Apple Watch** 的门店补货。
+查询 Apple 直营店的到店取货库存，有货时提醒你。提供 **桌面版、CLI 和 agent skill**。
 
-[项目介绍](https://enchigo.github.io/apple-pickup-watcher/) ·
-[English](https://enchigo.github.io/apple-pickup-watcher/en/) ·
-[下载最新正式版](https://github.com/ENCHIGO/apple-pickup-watcher/releases/latest) ·
-[安装说明](#安装) · [使用方法](#怎么用) · [常见问题](#常见问题--faq)
+支持 iPhone、iPad、Mac、Apple Watch；覆盖中国大陆、中国香港、中国台湾、日本、新加坡、澳大利亚和马来西亚。
+查询失败会显示带原因的「未知」，与「无货」区分。
 
-| 项目 | 支持范围 |
-| --- | --- |
-| 操作系统 | macOS（Apple Silicon / Intel）、Windows x64、Linux x86_64 |
-| 产品 | iPhone、iPad、Mac、Apple Watch；具体型号以应用目录为准 |
-| 地区 | 中国大陆、中国香港、中国台湾、日本、新加坡、澳大利亚、马来西亚 |
-| 通知 | 系统通知、提示音、可选 Bark 推送；窗口收进托盘后继续监控 |
-| 库存状态 | 有货 / 无货 / 未知，界面另行区分待查询；查询失败显示原因 |
-| 购买方式 | 可按设置打开购物袋；添加商品、选择取货门店、结账及付款由用户在 Apple 官网完成 |
-| 技术与许可 | Rust + Tauri v2 + React / TypeScript；GPL-3.0-or-later |
-
-需要保持应用运行、电脑联网且处于唤醒状态。程序不预留库存，也不保证购得；
-最终取货信息以 Apple 官网为准。具体版本及安装包见 [Releases](https://github.com/ENCHIGO/apple-pickup-watcher/releases)。
-
-**English — Apple Store pickup stock monitor and restock alerts.** Apple Pickup Watcher
-is a free, open-source desktop application for macOS, Windows and Linux. It monitors
-in-store pickup availability for iPhone, iPad, Mac and Apple Watch in China mainland,
-Hong Kong, Taiwan, Japan, Singapore, Australia and Malaysia. It offers desktop, sound
-and optional Bark alerts, and reports failed queries as **unknown**, not out of stock.
-Purchases are completed manually on Apple's website. This independent project is not
-affiliated with or endorsed by Apple Inc.
-
-It is a Rust + Tauri rewrite of [hteen/apple-store-helper](https://github.com/hteen/apple-store-helper).
-See [NOTICE](NOTICE) for attribution and [the FAQ](#常见问题--faq) for query-failure behavior.
-
----
-
-## 来源与许可
-
-本项目是 [hteen/apple-store-helper](https://github.com/hteen/apple-store-helper)（GPL-3.0）
-的重写版本。原项目已停止维护。
-
-本项目同样以 **GPL-3.0** 发布：
-
-- 原始许可全文在 [`LICENSE`](LICENSE)，未作任何删改。
-- 派生关系、原作者版权声明与修改摘要在 [`NOTICE`](NOTICE)。
-
-内嵌的门店与商品数据、以及整体的产品设计都来自原项目，因此 GPL 的义务继续适用 ——
-你可以自由使用、修改和再分发本项目，但衍生作品必须同样以 GPL-3.0 开源。
-
-**如果原项目对你仍然可用，请优先去支持原作者。** 这个项目存在的唯一理由是原项目已经
-不工作了，不是为了取代谁。
-
----
-
-## 为什么会有这个项目
-
-在排查原项目时，我们观察到它使用的 `/shop/fulfillment-messages` 请求返回 HTTP 541，
-但程序仍然把查不到的结果显示成「无货」。这些观察来自当时的请求和网络环境，
-不能推断接口在所有地区、所有网络或未来都不可用。
-
-真正需要避免的是**查询失败却被显示成无货**：程序看似还在刷新，用户却无法知道库存查询
-实际上没有成功。本项目改用 `/shop/retail/pickup-message`，并在核心类型中明确区分
-「有货 / 无货 / 未知」。未知必须带原因，包括网络失败、拦截、限流、无法识别的响应等。
-
-`Unknown` 构造时必须给出原因，`Availability` 不实现 `Default`，错误路径不能生成
-「无货」。实现和回归证据见 [库存类型](crates/apw-core/src/model.rs)、
-[Apple 客户端](crates/apw-core/src/apple.rs) 和 [响应解析测试](crates/apw-core/tests/parse.rs)。
-新接口也可能失败；显示失败原因是监控可靠性的一部分。
-
----
-
-## 相对 Go 版 v0.1.x 的变化
-
-v0.1.x 是 Go + Fyne 实现。v0.2.0 换成了 Rust + Tauri，界面重写为 React + TypeScript。
-
-| | v0.1.x（Go + Fyne） | 现在（Rust + Tauri） |
-| --- | --- | --- |
-| 发布体积 | 约 38 MB | 8 MB 量级 |
-| 关闭窗口 | 退出程序 | 收进系统托盘继续跑 |
-| 覆盖品类 | 只有 iPhone | iPhone / iPad / Mac / Apple Watch |
-| 型号列表 | 硬编码，等作者发版 | 可从 Apple 官网在线更新 |
-| 更新 | 手动看 Release | 应用内检查更新 |
-| 设置文件 | `settings.json` | `settings.v2.json` |
-
-几点说明：
-
-- **系统托盘。** 这个工具的正常用法是发售前挂上几个小时，所以关窗口收进托盘而不是退出；
-  真要退出走托盘菜单里的「退出」。到货提醒发在 Rust 侧而不是前端，因为托盘模式下窗口是
-  隐藏的，WebView 可能被系统节流甚至挂起 —— 把「及时提醒」挂在一个会被挂起的执行环境上
-  是不能接受的。
-- **型号列表可在线更新。** 界面上有「从 Apple 官网更新型号列表」的按钮，新机发售当天就能
-  获取已支持购买页上的最新型号。新增购买页 slug 的机型仍需先更新程序中的购买页清单；
-  这个按钮不会自动发现尚未配置的新购买页。按钮只抓**当前品类**的那几页 —— 四个品类加起来二十页购买页，
-  想看新出的 Mac 没有理由等 iPhone、iPad、Watch 一起抓完。抓不到时自动退回随程序内嵌的
-  离线快照，不会因此变得不可用。
-- **应用内更新检查只提示，不静默安装。** 发现新版本会在界面上显示一条提示，装不装由你点。
-- **配置可以共存、可以回退。** 设置文件换成了 `settings.v2.json`（两版的 JSON 字段命名不同，
-  共用一个文件名会让两个版本互相把对方的配置读成缺省值再覆盖掉）。首次启动时，如果新版
-  还没有任何监控目标，会自动把 Go 版 `settings.json` 里的配置迁移过来 —— 而那份旧文件
-  **原封不动地留着**，你想退回 v0.1.x 随时可以，配置一条都不会丢。
-
-体积下降只是换框架的附带结果，不是重写的理由。重写的理由写在上一节。
-
----
+[项目主页](https://enchigo.github.io/apple-pickup-watcher/) · [English](https://enchigo.github.io/apple-pickup-watcher/en/) · [下载桌面版](https://github.com/ENCHIGO/apple-pickup-watcher/releases/latest) · [CLI 文档](docs/cli.md) · [Agent skill](skills/apple-pickup-watcher/SKILL.md)
 
 ## 安装
 
-到 [Releases](https://github.com/ENCHIGO/apple-pickup-watcher/releases) 下载对应平台的安装包。
-macOS 分 Apple Silicon 与 Intel 两份，别下错。
+### 桌面版
 
-### macOS：安装后必须先解除隔离标记
+从 [Releases](https://github.com/ENCHIGO/apple-pickup-watcher/releases) 下载对应平台的安装包：
 
-安装包**没有经过 Apple 公证**（公证需要每年 99 美元的开发者账号）。直接双击会被 Gatekeeper
-拦下，提示「已损坏，无法打开」或「无法验证开发者」。把 `.app` 拖进「应用程序」之后执行：
+| 平台 | 架构 |
+| --- | --- |
+| macOS | Apple Silicon / Intel |
+| Windows | x64 |
+| Linux | x86_64 |
 
-```shell
+macOS 安装包未公证。将应用放进「应用程序」后，如提示无法打开，可执行：
+
+```bash
 xattr -cr "/Applications/Apple Pickup Watcher.app"
 ```
 
-然后正常打开即可。这条命令做的事是清掉下载文件被打上的 `com.apple.quarantine` 扩展属性 ——
-只对你自己刚下载的这一个应用生效，不会关掉系统的任何安全机制。
+Windows 安装提示、Linux 运行方式见 [桌面版指南](docs/desktop.md)。
 
-> 顺带一提：原项目的 issue #111「M4 Pro 上跑不起来」，**很可能**就是这件事。那类报告的表现
-> （新机器、下载后完全打不开、没有任何错误日志）与未公证应用被 Gatekeeper 拦截完全吻合，
-> 而不是芯片架构不兼容。这是根据现象做的推断，我们没有那台机器可以复现确认。
+### CLI
 
-### Windows
+安装 stable Rust 后，从源码安装 `apw`：
 
-安装包未做代码签名，SmartScreen 会提示「Windows 已保护你的电脑」。点「更多信息」→
-「仍要运行」。
+```bash
+git clone https://github.com/ENCHIGO/apple-pickup-watcher.git
+cd apple-pickup-watcher
+cargo install --path crates/apw-cli --locked
+```
 
-### Linux
+安装目录通常为 `~/.cargo/bin`，需要在 PATH 中。CLI 无需 Node、桌面环境或音频设备。
+预编译包可在 [CLI 构建记录](https://github.com/ENCHIGO/apple-pickup-watcher/actions/workflows/cli.yml) 的成功运行中下载（Artifacts，需要登录 GitHub），包内包含 skill 和文档。
 
-按 Release 页面提供的包格式安装。AppImage 需要自己加可执行权限：`chmod +x`。
+### Agent skill
 
----
+将仓库中的 [`skills/apple-pickup-watcher`](skills/apple-pickup-watcher/SKILL.md) 目录复制到 agent 的技能目录，并确保 agent 能运行 `apw`。
+Codex 的默认技能目录为 `~/.codex/skills`；配置了 `CODEX_HOME` 时使用其中的 `skills` 目录。
+已有同名 skill 时先比较内容，安装后在新会话中使用 `$apple-pickup-watcher`。
 
 ## 怎么用
 
-1. 选**地区**。地区决定了查哪个 Apple 在线商店，换地区后门店和型号会一起重选。
-2. 选**品类**（iPhone / iPad / Mac / Apple Watch）。它只是型号下拉框的筛选器，
-   已经加进列表的监控目标不受影响 —— 四个品类是混在一张表里盯的。
-3. 选**门店**和**型号**，点「添加」。可以加多条，不同品类、不同门店混着加都行。
-4. 点「开始」。表格里每一行会显示状态：有货 / 无货 / 未知 / 待查询，以及最后检查时间。
-5. 某一行从非有货变成有货时，会同时：弹系统通知、播提示音、发 Bark 推送（如已配置），
-   并按设置打开该地区的购物袋页面。每次「开始」到「暂停」期间最多自动打开一次购物袋，
-   多个目标或多个地区同时命中时，以第一个成功打开的地区为准，其余目标仍会提醒。
+### 桌面版
 
-命中后会**继续查询全部监控目标**，可通过每行的「最后检查」时间确认轮询是否在继续。
-同一次监控期间，持续有货不会每轮重复提醒；变为无货或未知后再次有货时才重新提醒。
-点击「暂停」再「开始」会重新启用所有目标的到货提醒：下一次查询确认仍有货，也会再次
-提醒并允许打开一次购物袋，无需删除重加。
+1. 选择地区、品类、门店和型号，添加监控目标。
+2. 点击「开始」，保持应用运行、电脑联网且处于唤醒状态；关闭窗口后会收进托盘继续监控。
+3. 确认有货时接收系统通知、提示音和可选的 Bark 推送。可按设置打开购物袋，购买操作由你在 Apple 官网完成。
 
-看到「监控当前不可信」的告警，说明有目标处于未知状态 —— 展开能看到具体原因（被拦截、
-被限流、接口结构变了……）。**这时候表格里的「无货」不代表真的没货**，告警消失前不要拿它
-当准信。
+默认每 30 秒查询，最低间隔为 5 秒。有货后继续监控；持续有货不重复提醒，离开有货状态后再次有货才重新提醒。
+[Bark、配置文件与通知设置](docs/desktop.md)。
 
-### 查询间隔
+### CLI / agent
 
-默认 **30 秒**，下限 **5 秒**。
+```bash
+# 查找地区、门店和具体 SKU
+apw regions
+apw stores --locale zh_CN --search 上海
+apw products --locale zh_CN --category iphone --search 512GB
 
-查询间隔越短，请求负担越高，也可能增加限流或拦截风险。默认 30 秒是在提醒及时性与
-请求频率之间的取舍，不代表这个频率一定不会被拦截。
+# 示例：指定门店与 SKU 查询一次；请换成你选中的编号
+apw check --locale zh_CN --store R359 --part 'MJTF4CH/A' --timeout 60
 
-填了小于 5 秒的值会被退回默认的 30 秒，而不是夹到 5 秒 —— 手抖填了 1 秒的人想要的是快，
-但 5 秒同样会被风控盯上，退回 30 秒才是安全的那一侧。
-
-### 配置文件位置
-
-| 平台 | 路径 |
-| --- | --- |
-| macOS | `~/Library/Application Support/apple-pickup-watcher/settings.v2.json` |
-| Windows | `%APPDATA%\apple-pickup-watcher\settings.v2.json` |
-| Linux | `$XDG_CONFIG_HOME/apple-pickup-watcher/settings.v2.json`（默认 `~/.config/...`） |
-
-配置写在系统约定的用户配置目录里，不是程序旁边 —— 打包成 macOS `.app` 之后，进程的工作
-目录取决于应用被如何启动，可能是 `/` 这种不可写的位置，写在那里会静默丢失。
-
-如果这个文件读不出来（磁盘损坏、被别的程序写坏了、手工编辑成了非法 JSON），程序**不会**
-拿默认配置继续跑然后把它覆盖掉 —— 那等于用一份空配置抹掉你攒了很久的监控列表。它会把
-原文件改名留档，然后在界面上告诉你档案存在哪。
-
-### Bark 推送
-
-[Bark](https://github.com/Finb/Bark) 是一个开源的 iOS 推送 App。装好后它会给你一个形如
-`https://api.day.app/你的Key` 的地址，把整段填进设置里的「Bark 推送地址」即可，留空则不推送。
-
-地址后面可以带查询参数，会原样保留，例如：
-
-```
-https://api.day.app/你的Key?group=库存&sound=alarm&level=critical
+# 等待任一目标有货，最多运行 5 分钟
+apw watch --targets targets.json --until-in-stock --timeout 300
 ```
 
-点「测试提醒」可以立刻走一遍完整的提醒链路（系统通知 + 提示音 + Bark），确认配置有效 ——
-不要等到发售当晚才发现推送没配对。
+`check` 返回 JSON，`watch` 逐行输出 NDJSON；批量目标格式、退出码和超时行为见 [CLI 文档](docs/cli.md)。
+`apw schema` 可查看机器可读的接口定义。退出码 0 表示查询成功，**不等于有货**；查询失败、缺失结果和超时不能当作无货。
 
-推送失败**不会**影响库存判定。渠道自己的问题就是渠道自己的问题，不能反过来改写已经确认
-的「有货」。
+安装 skill 后，可以直接对 agent 说：
 
----
+> 用 $apple-pickup-watcher 查一下上海 Apple 直营店的 iPhone 512GB 库存，先列出可选机型让我选。
 
-## 从源码构建
-
-### 工具链
-
-| 工具 | 版本 |
-| --- | --- |
-| Rust | 1.94（edition 2024；`Cargo.toml` 里声明的最低版本是 1.90） |
-| Node.js | 当前 LTS |
-| pnpm | 9 |
-
-### 系统依赖
-
-**macOS**：Xcode Command Line Tools（`xcode-select --install`）。
-
-**Windows**：Microsoft C++ 生成工具 与 WebView2 Runtime（Windows 11 已自带）。
-
-**Linux**（Debian / Ubuntu）：
-
-```shell
-sudo apt update
-sudo apt install -y \
-  libwebkit2gtk-4.1-dev build-essential curl wget file \
-  libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev \
-  libasound2-dev
-```
-
-前面那一组是 Tauri v2 官方前置依赖清单；最后的 `libasound2-dev` 是本项目额外需要的 ——
-提示音走 rodio，在 Linux 上最终落到 ALSA，缺了它会在**编译期**报找不到 `alsa.h`，而不是
-在运行时才安静地没声音。
-
-其他发行版的包名不同（Fedora 是 `webkit2gtk4.1-devel` 一套，Arch 是 `webkit2gtk-4.1` 一套），
-以 [Tauri v2 的前置依赖文档](https://v2.tauri.app/start/prerequisites/) 为准。
-
-### 命令
-
-```shell
-pnpm install                  # 首次
-pnpm tauri dev                # 起开发版应用
-pnpm tauri build              # 打安装包，产物在 target/release/bundle/
-```
-
-提交前跑这几条，和 CI 一致：
-
-```shell
-cargo test                                                    # 全部离线测试，不碰网络
-cargo clippy --all-targets --all-features -- -D warnings
-cargo fmt --all --check
-python3 crates/apw-core/data/generate.py --self-test           # 快照生成脚本自检，不联网
-pnpm test                                                     # 前端交互与异步状态回归，不联网
-pnpm exec tsc --noEmit
-pnpm exec vite build
-```
-
-### 代码结构
-
-```
-crates/apw-core/   核心逻辑，不依赖任何界面框架，可脱离 GUI 单独测试
-                     model          三态库存类型、地区表、品类与购买页、监控目标
-                     apple          Apple 接口客户端：限速、退避重试、错误分类、响应解析
-                     apple_catalog  从购买页抠出商品数据（两种页面排布都认）
-                     catalog        商品与门店目录（内嵌快照 + 在线刷新）
-                     watcher        调度引擎（actor 模型）
-                     notify         Bark 推送与提示音
-                     config         设置持久化与旧版迁移
-                   data/            内嵌离线快照，由 data/generate.py 重新生成
-src-tauri/         Tauri 应用外壳（crate 名 apw-app）：装配、IPC 转译、托盘、系统通知
-src/               React 19 + TypeScript 前端
-```
-
-有条边界是硬的：**所有业务判断都在 `apw-core` 里**，外壳层和前端不许出现任何「什么算有货」
-之类的逻辑。一旦让界面层参与判断，那条核心不变量就多了一处可以被绕开的地方。
-
-调度引擎用 actor 模型（一个任务独占全部状态，外界只能发消息）而不是「共享状态 + 锁」。
-原因写在 `crates/apw-core/src/watcher.rs` 的模块文档里 —— 简单说，共享状态那套写法在原项目
-里制造了一整类竞态（放锁去等待的窗口、第二条循环、`close(nil)` 崩进程、循环挂了之后叫不醒
-的僵尸引擎），而这类问题在 actor 结构下是**不存在**的，不是被堵住的。
-
----
-
-## 给维护者
-
-### main 受保护，改动一律走 PR
-
-`main` 上开了分支保护，**对仓库管理员同样生效**：
-
-| 规则 | 状态 |
-| --- | --- |
-| 合并前必须通过 `检查（Linux）`、`检查（macOS）` | 是 |
-| 禁止 force push | 是 |
-| 禁止删除分支 | 是 |
-| 对管理员同样生效（`enforce_admins`） | 是 |
-| 要求 PR review | 否 —— 单人仓库要求 approval 等于把自己锁在外面 |
-
-**这条会在发版时绊到你**：改版本号那一次提交也得走 PR，直接 `git push origin main` 会被
-拒绝，报 `2 of 2 required status checks are expected`。别以为是仓库坏了。
-
-要临时绕过（比如线上出事要立刻修），只能去 Settings → Branches 把规则关掉再打开 ——
-刻意没留后门，单人仓库最大的风险恰恰是自己手滑。
-
-`force push` 那条连管理员也挡，且**不受 `enforce_admins` 影响** —— 把 `enforce_admins`
-关掉也照样推不上去，这两个开关管的不是同一件事。所以想删掉一个已经推上 main 的提交，
-唯一的办法是去 Settings → Branches 临时勾上 Allow force pushes，推完立刻取消勾选。
-
-### 发布需要两个 GitHub Secret
-
-Tauri 的更新包需要签名，签名用两个仓库 Secret：
-
-| Secret | 说明 |
-| --- | --- |
-| `TAURI_SIGNING_PRIVATE_KEY` | minisign 私钥内容 |
-| `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` | 私钥密码（本项目生成时用的是**空密码**，仍需建这个 Secret，值留空） |
-
-对应的公钥已经写死在 `src-tauri/tauri.conf.json` 的 `plugins.updater.pubkey` 里。
-
-**两个 Secret 没设置时，流水线照常产出未签名的安装包，不会失败。** 这是刻意的 —— 仓库主人
-可能还没来得及配，不该因此连能装的包都拿不到。代价是这次发布的产物没有更新签名，老版本的
-应用内更新检查认不了它，用户得手动下载。
-
-> **私钥丢了就再也签不出能被老版本接受的更新包。**
->
-> 私钥在本机 `.tauri/` 目录下，该目录已被 `.gitignore` 排除（`.gitignore` 里同时排除了
-> `*.key`）。公钥编译进了已经发出去的每一个版本，换一把新密钥意味着所有存量用户的
-> 应用内更新永久失效，只能靠公告让他们手动重装。**请离线备份 `.tauri/` 下的私钥。**
-
-### 每天跑一次的真实接口契约测试
-
-```shell
-cargo test -p apw-core --features live --test live -- --nocapture --test-threads=1
-```
-
-它会依次查询七个地区的真实门店，检查四件事：接口还在不在、响应结构有没有变、
-`pickupDisplay` 有没有出现我们不认识的新取值、以及**我们是不是真的在用 HTTP/2**。
-
-最后那条是补上去的，因为它对应一类特别阴的缺陷：`reqwest` 的 HTTP/2 支持挂在 `http2`
-feature 上，而这个项目用的是 `default-features = false`。那个 feature 曾经漏了整整一个
-版本 —— 客户端静默退回 HTTP/1.1，查询照常成功、离线测试全绿，功能上一点征兆都没有。
-但我们的 UA 自称 Chrome 130，而真实的 Chrome 早就不用 HTTP/1.1 跟 apple.com 说话了；
-这个矛盾是最一眼可辨的机器人特征，在受风控审查的网络上直接换来一屏 HTTP 541
-（issue #3）。**配置写漏了、功能却没坏**的问题，只有真的去连一次才发现得了。
-
-**这个测试就是为了不重蹈上游覆辙而存在的。** 上游正是因为 Apple 悄悄换掉了接口而彻底失效，
-却因为没有任何真实接口测试，半年时间里没人发现程序返回的「无货」其实是被拦截。用假响应
-写的单元测试验证的是解析逻辑，拦不住这种事 —— 只有真的打一次 Apple 才行。
-
-它失败时要看的是「Apple 是不是又改了接口」，而不是「测试是不是又不稳定了」。
-
-两条纪律：
-
-- **常规 CI 绝对不要跑它。** 它会真的向 Apple 发请求。每次 push 都跑等于替所有贡献者
-  一起去打扰 Apple 的服务器。
-- **按天定时跑。** 每天一次足够及时发现接口变更，也足够克制。
-
-测试里那张零件号表（`crates/apw-core/tests/live.rs` 的 `CASES`）会随机型更新而失效。届时
-应当**更新这张表，而不是删掉测试**。
-
-### 重新生成内嵌的离线快照
-
-```shell
-python3 crates/apw-core/data/generate.py
-```
-
-它会把七个地区、四个品类共二十页购买页各抓一遍，把用得到的字段裁出来写进
-`crates/apw-core/data/products_<locale>.json`。抓不全时**非零退出**且不掩盖失败 ——
-静默写出一份缺页的快照，等于把「兜底目录」变成「兜底目录里刚好没有你要的那台机器」。
-
-平时不需要跑它：程序运行时会自己从购买页现抓，快照只是断网或被拦截时的兜底。
-真正需要跑的时候是两种：Apple 换了新一代机型（`model.rs` 的 `DEFAULT_FAMILIES` 里
-加了新 slug），或者购买页的数据结构变了。上游是把这份数据手工从浏览器开发者工具里
-复制进仓库，于是每发一代新机都得等作者更新并发版。
-
-### 打包平台
-
-macOS 的 Intel 构建用 `macos-15-intel` runner，arm64 用 `macos-latest`。
-
-上一代的 `macos-13` 标签已于 2025-12-04 退役，写它会让作业在初始化阶段就直接失败 ——
-连日志都没有，只有一行调度错误。这个坑本项目踩过一次，整条发布流水线因此空转。
-改这里之前请先确认新标签当前有效。
-
----
+CLI 和 skill 负责查询与监控，命令退出后监控结束。
 
 ## 常见问题 / FAQ
 
-### 如何监控 iPhone 或其他 Apple 产品的门店到货？
+- 安装、HTTP 541、通知和配置问题：[桌面版指南](docs/desktop.md)。
+- 批量查询、事件流和 agent 接入：[CLI 文档](docs/cli.md)。
+- 开发环境、测试和发布流程：[开发与维护](docs/development.md)。
+- 报告问题：[GitHub Issues](https://github.com/ENCHIGO/apple-pickup-watcher/issues)，请附版本、地区、门店/SKU 和脱敏日志。
 
-下载并安装对应系统的版本，选择地区、品类、门店和型号，添加监控目标后点击「开始」。
-默认每 30 秒查询一次；发现目标从非有货变为有货时发送通知。完整步骤见[怎么用](#怎么用)。
+## 来源与许可
 
-### 可以自动下单、预留库存或保证买到吗？
+本项目是 [hteen/apple-store-helper](https://github.com/hteen/apple-store-helper) 的 Rust 重写，按 **GPL-3.0-or-later** 发布。许可与来源说明见 [LICENSE](LICENSE) 和 [NOTICE](NOTICE)。
 
-不可以。程序可以按设置打开购物袋，但添加商品、选择取货门店、结账和付款均由用户
-在 Apple 官网完成。提醒后库存仍可能变化，工具不预留库存，也不保证购得。
-
-### 为什么有些库存工具一直显示「无货」，但官网明明有货？
-
-需要先确认工具是否真正成功查询。我们在排查上游 `apple-store-helper` 时发现，
-请求失败后返回的空结果会在上层被当成无货，这会掩盖网络或接口问题。
-Apple Pickup Watcher 把查询失败显示为带原因的「未知」，与有效响应中的「无货」分开。
-门店、型号、地区或查询时间不同，也可能造成与官网结果不一致。
-
-### HTTP 541 是什么意思？
-
-在本项目的 Apple 请求中，HTTP 541 被作为拦截类查询失败处理，不表示无货。
-仅凭这个状态码，不能确定是 Cookie、网络环境还是 Apple 侧策略导致，也不能证明
-某个接口已对所有人永久停用。请结合应用日志、版本、地区与请求环境排查。
-
-### 程序被拦截，但浏览器打开 Apple 官网正常，怎么办？
-
-浏览器和应用的 Cookie、请求上下文及网络路径可能不同。针对
-[issue #3](https://github.com/ENCHIGO/apple-pickup-watcher/issues/3) 中的报告，
-v0.3.2 起客户端会先访问购买页建立 Cookie 会话，再查询库存；被拦截时会重建会话。
-这是对已观察问题的修复，不能保证所有环境都不再遇到 HTTP 541。
-
-先升级到最新正式版；仍然失败时，请在 [Issues](https://github.com/ENCHIGO/apple-pickup-watcher/issues)
-附上应用版本、地区和脱敏后的日志。不要提交 Bark Key、Cookie 或其他凭据。
-降低查询频率可能减轻请求负担，但不保证解决拦截问题。
-
-### 项目使用哪个库存接口？
-
-当前客户端使用 `/shop/retail/pickup-message`。请求构造和状态解释以
-[Apple 客户端源码](crates/apw-core/src/apple.rs) 为准，离线响应契约见
-[解析测试](crates/apw-core/tests/parse.rs)。项目另有每天运行的真实接口测试，
-结果可在 [GitHub Actions](https://github.com/ENCHIGO/apple-pickup-watcher/actions/workflows/ci.yml)
-查看；一次成功不代表所有用户网络都可用。
-
-### What is the difference between unknown and out of stock?
-
-Out of stock means a successful query returned a recognized unavailable pickup result.
-Unknown means the query could not determine availability, for example because of a
-network failure, a block, a rate limit or an unrecognized response. HTTP 541 is treated
-as a failed query, not proof that a device is out of stock. A successful check in one
-network does not guarantee success in another.
-
-### 这个项目与 Apple 官方、上游项目是什么关系？
-
-这是独立开源项目，与 Apple Inc. 无关联，也未获其授权或认可。
-它是 `hteen/apple-store-helper` 的 Rust + Tauri 重写版本，保留 GPL 许可及来源声明，
-详见 [NOTICE](NOTICE) 与 [LICENSE](LICENSE)。核心差异包括失败状态可见、后台托盘监控、
-多品类支持与到货通知。具体能力以正式发布版本为准。
-
----
-
-## 免责声明
-
-本工具仅供**个人查询**使用，与 Apple Inc. 没有任何关系，不是 Apple 的产品，也未获得
-Apple 的授权或认可。
-
-请合理设置查询频率。默认 30 秒、下限 5 秒是经过考虑的取值，不是随手填的。把它调到贴着
-下限跑，对你自己的收益接近于零（门店库存不会在 5 秒内反复横跳），对 Apple 的服务器却是
-实打实的负担，还会让你更快被风控盯上。
-
-**请不要用它做批量抢购牟利。** 这个工具是为了让想买手机的人别错过补货，不是为了给黄牛
-提效。真那么用了，最先被封的是这条路本身，然后所有人都用不了。
-
-因使用本工具造成的任何后果由使用者自行承担。
-
----
-
-## 许可
-
-GPL-3.0-or-later。详见 [`LICENSE`](LICENSE) 与 [`NOTICE`](NOTICE)。
+本项目与 Apple Inc. 无关联。仅供个人查询，不预留库存；最终库存与取货信息以 Apple 官网为准。

--- a/crates/apw-cli/Cargo.toml
+++ b/crates/apw-cli/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "apw-cli"
+description = "Agent-friendly CLI for Apple Retail pickup availability"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "apw"
+path = "src/main.rs"
+
+[dependencies]
+apw-core = { path = "../apw-core", default-features = false }
+clap = { version = "4.5", features = ["derive"] }
+tokio = { workspace = true, features = ["signal", "io-std", "io-util", "fs"] }
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/apw-cli/src/args.rs
+++ b/crates/apw-cli/src/args.rs
@@ -1,0 +1,115 @@
+use std::path::PathBuf;
+
+use apw_core::model::Category;
+use clap::{Args, Parser, Subcommand, ValueEnum};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "apw",
+    version,
+    about = "Apple pickup availability for agents. JSON output; watch emits NDJSON."
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// List supported region identifiers (offline).
+    Regions,
+    /// List retail stores (offline).
+    Stores {
+        #[arg(long, default_value = "zh_CN")]
+        locale: String,
+        /// Match store number or name, case-insensitively.
+        #[arg(long)]
+        search: Option<String>,
+    },
+    /// List products; explicitly refresh to fetch current buying pages.
+    Products {
+        #[arg(long, default_value = "zh_CN")]
+        locale: String,
+        #[arg(long, value_enum, required_if_eq("refresh", "true"))]
+        category: Option<ProductCategory>,
+        /// Match SKU, title, family, capacity or color, case-insensitively.
+        #[arg(long)]
+        search: Option<String>,
+        /// Refresh this category in memory; failed pages retain embedded data.
+        #[arg(long)]
+        refresh: bool,
+        /// Overall deadline in seconds, including refresh and output.
+        #[arg(long, default_value_t = 120, value_parser = clap::value_parser!(u64).range(1..=86400))]
+        timeout: u64,
+    },
+    /// Complete one polling cycle. Exit 0 means known, not necessarily in stock.
+    Check {
+        #[command(flatten)]
+        targets: TargetArgs,
+        /// Overall deadline in seconds, including reading target input.
+        #[arg(long, default_value_t = 60, value_parser = clap::value_parser!(u64).range(1..=86400))]
+        timeout: u64,
+    },
+    /// Emit watcher events as NDJSON. No desktop, sound or push side effects.
+    Watch {
+        #[command(flatten)]
+        targets: TargetArgs,
+        /// Base interval in seconds; engine jitter and failure backoff still apply.
+        #[arg(long, default_value_t = 30, value_parser = clap::value_parser!(u64).range(5..=86400))]
+        interval: u64,
+        /// Exit successfully on the first confirmed in-stock event (any target).
+        #[arg(long)]
+        until_in_stock: bool,
+        /// Overall deadline in seconds; 0 explicitly enables unlimited monitoring.
+        #[arg(long, default_value_t = 300, value_parser = clap::value_parser!(u64).range(0..=604800))]
+        timeout: u64,
+    },
+    /// Describe commands, exit codes and the versioned JSON data contract (offline).
+    Schema,
+}
+
+impl Cli {
+    pub fn timeout_seconds(&self) -> u64 {
+        match &self.command {
+            Command::Products { timeout, .. }
+            | Command::Check { timeout, .. }
+            | Command::Watch { timeout, .. } => *timeout,
+            _ => 60,
+        }
+    }
+}
+
+#[derive(Debug, Args)]
+pub struct TargetArgs {
+    /// Explicit locale for --store/--part, e.g. zh_CN.
+    #[arg(long, requires_all = ["store", "part"])]
+    pub locale: Option<String>,
+    /// Store number. Repeat to query every store/part combination.
+    #[arg(long, requires_all = ["locale", "part"], value_delimiter = ',')]
+    pub store: Vec<String>,
+    /// Apple part number (SKU), e.g. MWUC3CH/A. Repeat for multiple products.
+    #[arg(long, requires_all = ["locale", "store"], value_delimiter = ',')]
+    pub part: Vec<String>,
+    /// JSON array of targets from a file; '-' reads stdin. Maximum 256 targets / 1 MiB.
+    #[arg(long, conflicts_with_all = ["locale", "store", "part"])]
+    pub targets: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ProductCategory {
+    Iphone,
+    Ipad,
+    Mac,
+    Watch,
+}
+
+impl From<ProductCategory> for Category {
+    fn from(value: ProductCategory) -> Self {
+        match value {
+            ProductCategory::Iphone => Self::Iphone,
+            ProductCategory::Ipad => Self::Ipad,
+            ProductCategory::Mac => Self::Mac,
+            ProductCategory::Watch => Self::Watch,
+        }
+    }
+}

--- a/crates/apw-cli/src/data-schema.json
+++ b/crates/apw-cli/src/data-schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "APW CLI v1 data contract",
+  "$defs": {
+    "inputTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["locale", "storeNumber", "partNumber"],
+      "properties": {
+        "locale": {"type": "string"},
+        "storeNumber": {"type": "string", "pattern": "^R[0-9]+$", "maxLength": 12},
+        "partNumber": {"type": "string", "pattern": "^[A-Za-z0-9]+(/[A-Za-z0-9]+)?$", "maxLength": 64},
+        "storeTitle": {"type": "string"},
+        "productName": {"type": "string"}
+      }
+    },
+    "targets": {"type": "array", "minItems": 1, "maxItems": 256, "items": {"$ref": "#/$defs/inputTarget"}},
+    "availability": {
+      "oneOf": [
+        {"type": "object", "required": ["kind"], "properties": {"kind": {"enum": ["in_stock", "out_of_stock"]}}},
+        {
+          "type": "object", "required": ["kind", "reason"], "properties": {"kind": {"const": "unknown"}},
+          "oneOf": [
+            {"properties": {"reason": {"enum": ["not_yet_checked", "rate_limited"]}}},
+            {"required": ["detail"], "properties": {"reason": {"enum": ["blocked", "transport"]}, "detail": {"type": "string"}}},
+            {"required": ["field", "raw"], "properties": {"reason": {"const": "schema_drift"}, "field": {"type": "string"}, "raw": {"type": "string"}}},
+            {"required": ["message"], "properties": {"reason": {"const": "apple_error"}, "message": {"type": "string"}}}
+          ]
+        }
+      ]
+    },
+    "targetState": {
+      "type": "object", "required": ["target", "availability", "lastCheckedMs", "consecutiveFailures"],
+      "properties": {
+        "target": {"$ref": "#/$defs/inputTarget"},
+        "availability": {"$ref": "#/$defs/availability"},
+        "lastCheckedMs": {"type": ["integer", "null"], "minimum": 0},
+        "consecutiveFailures": {"type": "integer", "minimum": 0}
+      }
+    },
+    "event": {
+      "type": "object", "required": ["type"],
+      "oneOf": [
+        {"required": ["state"], "properties": {"type": {"enum": ["stateChanged", "inStock"]}, "state": {"$ref": "#/$defs/targetState"}}},
+        {"required": ["healthy", "snapshot"], "properties": {"type": {"const": "cycleComplete"}, "healthy": {"type": "boolean"}, "snapshot": {"type": "array", "items": {"$ref": "#/$defs/targetState"}}}},
+        {"required": ["reason", "advice"], "properties": {"type": {"const": "trouble"}, "reason": {"type": "string"}, "advice": {"enum": [null, "try_another_network", "wait_for_update"]}}},
+        {"required": ["running"], "properties": {"type": {"const": "runStateChanged"}, "running": {"type": "boolean"}}}
+      ]
+    },
+    "check": {
+      "type": "object", "required": ["schemaVersion", "command", "healthy", "anyInStock", "snapshot"],
+      "properties": {
+        "schemaVersion": {"const": 1}, "command": {"const": "check"},
+        "healthy": {"type": "boolean"}, "anyInStock": {"type": "boolean"},
+        "snapshot": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/targetState"}}
+      }
+    },
+    "watch": {
+      "type": "object", "required": ["schemaVersion", "command", "event"],
+      "properties": {"schemaVersion": {"const": 1}, "command": {"const": "watch"}, "event": {"$ref": "#/$defs/event"}}
+    },
+    "error": {
+      "type": "object", "required": ["schemaVersion", "error"],
+      "properties": {
+        "schemaVersion": {"const": 1},
+        "error": {"type": "object", "required": ["kind", "message", "exitCode"], "properties": {
+          "kind": {"type": "string"}, "message": {"type": "string"}, "exitCode": {"type": "integer"}
+        }}
+      }
+    }
+  }
+}

--- a/crates/apw-cli/src/lib.rs
+++ b/crates/apw-cli/src/lib.rs
@@ -1,0 +1,393 @@
+//! CLI transport and input validation. Inventory decisions remain in apw-core.
+
+pub mod args;
+mod schema;
+
+use std::collections::BTreeSet;
+use std::future::Future;
+use std::io;
+use std::time::Duration;
+
+use apw_core::apple::{AppleClient, ClientConfig, Fetcher};
+use apw_core::catalog::Catalog;
+use apw_core::model::{REGIONS, Region, Target, region_by_locale};
+use apw_core::watcher::{Event, Watcher, WatcherConfig};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+use args::{Cli, Command, TargetArgs};
+
+pub const SCHEMA_VERSION: u32 = 1;
+pub const MAX_TARGETS: usize = 256;
+pub const MAX_INPUT_BYTES: u64 = 1 << 20;
+
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+pub struct CliError {
+    pub exit_code: u8,
+    pub kind: &'static str,
+    pub message: String,
+}
+
+impl CliError {
+    pub fn new(exit_code: u8, kind: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            exit_code,
+            kind,
+            message: message.into(),
+        }
+    }
+
+    pub fn invalid(message: impl Into<String>) -> Self {
+        Self::new(2, "invalid_input", message)
+    }
+
+    pub fn json(&self) -> Value {
+        json!({"schemaVersion": SCHEMA_VERSION, "error": {
+            "kind": self.kind, "message": self.message, "exitCode": self.exit_code
+        }})
+    }
+}
+
+impl From<io::Error> for CliError {
+    fn from(error: io::Error) -> Self {
+        if error.kind() == io::ErrorKind::BrokenPipe {
+            Self::new(141, "broken_pipe", "Output consumer closed the pipe")
+        } else {
+            Self::new(1, "io_error", error.to_string())
+        }
+    }
+}
+
+pub async fn json_line<W: AsyncWrite + Unpin, T: Serialize>(
+    out: &mut W,
+    value: &T,
+) -> Result<(), CliError> {
+    let mut bytes = serde_json::to_vec(value)
+        .map_err(|e| CliError::new(1, "serialization_error", e.to_string()))?;
+    bytes.push(b'\n');
+    out.write_all(&bytes).await?;
+    out.flush().await?;
+    Ok(())
+}
+
+/// Deadline covers the entire operation, including stdin and output backpressure.
+/// Dropping the operation cancels its watcher via EngineTask below.
+pub async fn bounded<F, S>(operation: F, seconds: u64, shutdown: S) -> Result<u8, CliError>
+where
+    F: Future<Output = Result<u8, CliError>>,
+    S: Future<Output = Result<u8, CliError>>,
+{
+    let deadline = async {
+        if seconds == 0 {
+            std::future::pending::<()>().await;
+        } else {
+            tokio::time::sleep(Duration::from_secs(seconds)).await;
+        }
+    };
+    tokio::select! {
+        biased;
+        code = shutdown => Err(CliError::new(code?, "interrupted", "Monitoring interrupted")),
+        _ = deadline => Err(CliError::new(4, "timeout", format!("Deadline of {seconds} seconds exceeded"))),
+        result = operation => result,
+    }
+}
+
+fn region(locale: &str) -> Result<&'static Region, CliError> {
+    region_by_locale(locale)
+        .ok_or_else(|| CliError::invalid(format!("Unsupported locale {locale:?}; run apw regions")))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct InputTarget {
+    pub locale: String,
+    pub store_number: String,
+    pub part_number: String,
+    #[serde(default)]
+    pub store_title: String,
+    #[serde(default)]
+    pub product_name: String,
+}
+
+pub async fn read_targets<R: AsyncRead + Unpin>(reader: R) -> Result<Vec<InputTarget>, CliError> {
+    let mut bytes = Vec::new();
+    reader
+        .take(MAX_INPUT_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .await?;
+    if bytes.len() as u64 > MAX_INPUT_BYTES {
+        return Err(CliError::invalid("Target input exceeds 1 MiB"));
+    }
+    serde_json::from_slice(&bytes)
+        .map_err(|e| CliError::invalid(format!("Invalid target JSON: {e}")))
+}
+
+pub fn resolve_targets(
+    inputs: Vec<InputTarget>,
+    catalog: &Catalog,
+) -> Result<Vec<Target>, CliError> {
+    if inputs.is_empty() || inputs.len() > MAX_TARGETS {
+        return Err(CliError::invalid("Supply between 1 and 256 targets"));
+    }
+    let mut seen = BTreeSet::new();
+    let mut targets = Vec::new();
+    for input in inputs {
+        region(&input.locale)?;
+        let store = &input.store_number;
+        if !(2..=12).contains(&store.len())
+            || !store.starts_with('R')
+            || !store[1..].bytes().all(|b| b.is_ascii_digit())
+        {
+            return Err(CliError::invalid(format!(
+                "Invalid store number {store:?}; expected R followed by digits"
+            )));
+        }
+        let part = &input.part_number;
+        if part.is_empty()
+            || part.len() > 64
+            || !part.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'/')
+            || !part.as_bytes()[0].is_ascii_alphanumeric()
+            || !part.as_bytes()[part.len() - 1].is_ascii_alphanumeric()
+            || part.bytes().filter(|b| *b == b'/').count() > 1
+        {
+            return Err(CliError::invalid(format!(
+                "Invalid part number {part:?}; use the SKU returned by apw products"
+            )));
+        }
+        // Catalog absence is not proof of an invalid SKU/store: embedded data can lag.
+        let store_title = if input.store_title.is_empty() {
+            catalog
+                .store_by_number(&input.locale, store)
+                .map_or_else(|| store.clone(), |s| s.title)
+        } else {
+            input.store_title
+        };
+        let product_name = if input.product_name.is_empty() {
+            catalog
+                .product_by_part(&input.locale, part)
+                .map_or_else(|| part.clone(), |p| p.title)
+        } else {
+            input.product_name
+        };
+        let target = Target {
+            locale: input.locale,
+            store_number: input.store_number,
+            part_number: input.part_number,
+            store_title,
+            product_name,
+        };
+        if seen.insert(target.key()) {
+            targets.push(target);
+        }
+    }
+    Ok(targets)
+}
+
+async fn load_targets(args: TargetArgs, catalog: &Catalog) -> Result<Vec<Target>, CliError> {
+    let inputs = if let Some(path) = args.targets {
+        if path.as_os_str() == "-" {
+            read_targets(tokio::io::stdin()).await?
+        } else {
+            let file = tokio::fs::File::open(&path)
+                .await
+                .map_err(|e| CliError::invalid(format!("Cannot read {}: {e}", path.display())))?;
+            read_targets(file).await?
+        }
+    } else {
+        let locale = args.locale.ok_or_else(|| {
+            CliError::invalid("Supply --locale, --store and --part, or --targets FILE/-")
+        })?;
+        if args.store.len().saturating_mul(args.part.len()) > MAX_TARGETS {
+            return Err(CliError::invalid(
+                "Store/part combinations exceed 256 targets",
+            ));
+        }
+        args.store
+            .iter()
+            .flat_map(|store| {
+                args.part.iter().map(|part| InputTarget {
+                    locale: locale.clone(),
+                    store_number: store.clone(),
+                    part_number: part.clone(),
+                    store_title: String::new(),
+                    product_name: String::new(),
+                })
+            })
+            .collect()
+    };
+    resolve_targets(inputs, catalog)
+}
+
+fn matches_search(search: &Option<String>, values: &[&str]) -> bool {
+    search.as_ref().is_none_or(|q| {
+        let q = q.to_lowercase();
+        values.iter().any(|v| v.to_lowercase().contains(&q))
+    })
+}
+
+pub async fn execute<W: AsyncWrite + Unpin>(cli: Cli, out: &mut W) -> Result<u8, CliError> {
+    let catalog = Catalog::new();
+    match cli.command {
+        Command::Regions => {
+            let regions: Vec<_> = REGIONS
+                .iter()
+                .map(|r| json!({"locale": r.locale, "title": r.title, "baseUrl": r.base_url}))
+                .collect();
+            json_line(
+                out,
+                &json!({"schemaVersion": SCHEMA_VERSION, "command": "regions", "regions": regions}),
+            )
+            .await?;
+        }
+        Command::Stores { locale, search } => {
+            region(&locale)?;
+            let stores: Vec<_> = catalog
+                .stores(&locale)
+                .map_err(catalog_error)?
+                .into_iter()
+                .filter(|s| matches_search(&search, &[&s.number, &s.name, &s.title]))
+                .collect();
+            json_line(out, &json!({"schemaVersion": SCHEMA_VERSION, "command": "stores", "locale": locale, "source": "embedded", "stores": stores})).await?;
+        }
+        Command::Products {
+            locale,
+            category,
+            search,
+            refresh,
+            ..
+        } => {
+            let region = region(&locale)?;
+            let category = category.map(Into::into);
+            let mut warning = None;
+            if refresh {
+                let http = reqwest::Client::builder()
+                    .timeout(Duration::from_secs(15))
+                    .connect_timeout(Duration::from_secs(5))
+                    .build()
+                    .map_err(|e| CliError::new(1, "client_error", e.to_string()))?;
+                if let Err(error) = catalog.refresh_products(region, category, &http).await {
+                    warning = Some(error.to_string());
+                }
+            }
+            let products: Vec<_> = catalog
+                .products(&locale)
+                .map_err(catalog_error)?
+                .into_iter()
+                .filter(|p| category.is_none_or(|c| c == p.category))
+                .filter(|p| {
+                    matches_search(
+                        &search,
+                        &[&p.part_number, &p.title, &p.family, &p.capacity, &p.color],
+                    )
+                })
+                .collect();
+            let complete = warning.is_none();
+            let source = if !refresh {
+                "embedded"
+            } else if complete {
+                "online"
+            } else {
+                "online_with_embedded_fallback"
+            };
+            json_line(out, &json!({"schemaVersion": SCHEMA_VERSION, "command": "products", "locale": locale,
+                "source": source, "refreshComplete": if refresh { Some(complete) } else { None }, "warning": warning, "products": products})).await?;
+            return Ok(if complete { 0 } else { 3 });
+        }
+        Command::Check { targets, .. } => {
+            let targets = load_targets(targets, &catalog).await?;
+            let client = AppleClient::new(ClientConfig::default())
+                .map_err(|e| CliError::new(1, "client_error", e.to_string()))?;
+            return monitor(client, targets, WatcherConfig::default(), Mode::Check, out).await;
+        }
+        Command::Watch {
+            targets,
+            interval,
+            until_in_stock,
+            ..
+        } => {
+            let targets = load_targets(targets, &catalog).await?;
+            let client = AppleClient::new(ClientConfig::default())
+                .map_err(|e| CliError::new(1, "client_error", e.to_string()))?;
+            let config = WatcherConfig {
+                interval: Duration::from_secs(interval),
+                ..WatcherConfig::default()
+            };
+            return monitor(client, targets, config, Mode::Watch { until_in_stock }, out).await;
+        }
+        Command::Schema => json_line(out, &schema::document()).await?,
+    }
+    Ok(0)
+}
+
+fn catalog_error(error: apw_core::catalog::CatalogError) -> CliError {
+    CliError::new(1, "catalog_error", error.to_string())
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Mode {
+    Check,
+    Watch { until_in_stock: bool },
+}
+
+struct EngineTask(tokio::task::JoinHandle<()>);
+impl Drop for EngineTask {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+/// Shared adapter, tested using a fake Fetcher and the real core engine.
+pub async fn monitor<F: Fetcher, W: AsyncWrite + Unpin>(
+    client: F,
+    targets: Vec<Target>,
+    config: WatcherConfig,
+    mode: Mode,
+    out: &mut W,
+) -> Result<u8, CliError> {
+    if targets.is_empty() {
+        return Err(CliError::invalid("No targets"));
+    }
+    let (watcher, mut events, engine) = Watcher::new(client, config);
+    let _engine = EngineTask(tokio::spawn(engine));
+    watcher.set_targets(targets).await;
+    watcher.start().await;
+    while let Some(event) = events.recv().await {
+        match mode {
+            Mode::Check => {
+                if let Event::CycleComplete { healthy, snapshot } = event {
+                    let healthy = healthy
+                        && !snapshot.is_empty()
+                        && snapshot.iter().all(|s| !s.availability.is_unknown());
+                    let any_in_stock = snapshot.iter().any(|s| s.availability.is_in_stock());
+                    watcher.stop().await;
+                    json_line(
+                        out,
+                        &json!({"schemaVersion": SCHEMA_VERSION, "command": "check",
+                        "healthy": healthy, "anyInStock": any_in_stock, "snapshot": snapshot}),
+                    )
+                    .await?;
+                    return Ok(if healthy { 0 } else { 3 });
+                }
+            }
+            Mode::Watch { until_in_stock } => {
+                let hit = matches!(event, Event::InStock { .. });
+                json_line(
+                    out,
+                    &json!({"schemaVersion": SCHEMA_VERSION, "command": "watch", "event": event}),
+                )
+                .await?;
+                if until_in_stock && hit {
+                    watcher.stop().await;
+                    return Ok(0);
+                }
+            }
+        }
+    }
+    Err(CliError::new(
+        1,
+        "engine_stopped",
+        "Watcher event stream closed unexpectedly",
+    ))
+}

--- a/crates/apw-cli/src/main.rs
+++ b/crates/apw-cli/src/main.rs
@@ -1,0 +1,68 @@
+use std::io::Write;
+use std::process::ExitCode;
+use std::time::Duration;
+
+use apw_cli::args::Cli;
+use apw_cli::{CliError, bounded, execute};
+use clap::Parser;
+
+fn report(error: CliError) -> ExitCode {
+    // A consumer such as head can close the pipe intentionally; don't print a panic.
+    if error.exit_code != 141 {
+        let _ = writeln!(std::io::stderr().lock(), "{}", error.json());
+    }
+    ExitCode::from(error.exit_code)
+}
+
+fn main() -> ExitCode {
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(error) => {
+            if matches!(
+                error.kind(),
+                clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion
+            ) {
+                return match write!(std::io::stdout().lock(), "{error}") {
+                    Ok(()) => ExitCode::SUCCESS,
+                    Err(error) => report(error.into()),
+                };
+            }
+            return report(CliError::new(2, "invalid_arguments", error.to_string()));
+        }
+    };
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(error) => return report(CliError::new(1, "runtime_error", error.to_string())),
+    };
+    let seconds = cli.timeout_seconds();
+    let result = runtime.block_on(async {
+        bounded(execute(cli, &mut tokio::io::stdout()), seconds, shutdown()).await
+    });
+    // Tokio's stdin/stdout use blocking workers. An unclosed input pipe must not
+    // keep the process alive after its overall deadline or a termination signal.
+    runtime.shutdown_timeout(Duration::from_millis(200));
+    match result {
+        Ok(code) => ExitCode::from(code),
+        Err(error) => report(error),
+    }
+}
+
+async fn shutdown() -> Result<u8, CliError> {
+    #[cfg(unix)]
+    {
+        let mut terminate =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => { result?; Ok(130) },
+            _ = terminate.recv() => Ok(143),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await?;
+        Ok(130)
+    }
+}

--- a/crates/apw-cli/src/schema.rs
+++ b/crates/apw-cli/src/schema.rs
@@ -1,0 +1,41 @@
+use apw_core::model::REGIONS;
+use clap::CommandFactory;
+use serde_json::{Value, json};
+
+use crate::{SCHEMA_VERSION, args::Cli};
+
+pub fn document() -> Value {
+    let mut cli = Cli::command();
+    cli.build();
+    let commands: Vec<_> = cli.get_subcommands().map(|command| {
+        let arguments: Vec<_> = command.get_arguments().map(|arg| {
+            let values = arg.get_value_parser().possible_values().map(|values|
+                values.map(|v| v.get_name().to_owned()).collect::<Vec<_>>());
+            json!({"name": arg.get_id().as_str(), "long": arg.get_long(),
+                "help": arg.get_help().map(ToString::to_string), "required": arg.is_required_set(),
+                "action": format!("{:?}", arg.get_action()),
+                "defaultValues": arg.get_default_values().iter().map(|v| v.to_string_lossy()).collect::<Vec<_>>(),
+                "possibleValues": values})
+        }).collect();
+        json!({"name": command.get_name(), "description": command.get_about().map(ToString::to_string), "arguments": arguments,
+            "help": command.clone().render_long_help().to_string()})
+    }).collect();
+    let locales: Vec<_> = REGIONS.iter().map(|r| r.locale).collect();
+    let mut data_schema: Value =
+        serde_json::from_str(include_str!("data-schema.json")).expect("embedded JSON schema");
+    data_schema["$defs"]["inputTarget"]["properties"]["locale"]["enum"] = json!(locales);
+    json!({"schemaVersion": SCHEMA_VERSION, "command": "schema", "version": env!("CARGO_PKG_VERSION"),
+        "commands": commands, "dataSchema": data_schema,
+        "exitCodes": {"0": "Known check result (including out of stock), catalog result, or watch condition satisfied",
+            "1": "Internal or I/O failure", "2": "Invalid arguments or input", "3": "Unknown stock or incomplete catalog refresh",
+            "4": "Overall deadline exceeded", "130": "Interrupted (Ctrl-C)", "141": "Output pipe closed", "143": "Terminated (SIGTERM)"},
+        "transport": {"stdout": "JSON; watch emits one flushed JSON object per line (NDJSON)",
+            "stderr": "JSON error object; help/version are human-readable exceptions",
+            "timeUnit": "seconds for flags; Unix milliseconds for lastCheckedMs", "maxTargets": 256, "maxInputBytes": 1048576},
+        "semantics": {"watchUntilInStock": "Any target; first confirmed inStock event exits 0",
+            "watchDeadline": "Exit 4 even if earlier cycles were healthy; prior rows remain historical observations",
+            "targetFlags": "--locale/--store/--part together, or --targets FILE/- exclusively; repeated stores and parts form a Cartesian product",
+            "refresh": "Requires --category; in-memory only; failed pages keep embedded data and exit 3",
+            "availability": "Only in_stock confirms stock. unknown never means out_of_stock; not_yet_checked is pending",
+            "limits": "--interval >= 5; bounded by default; only watch --timeout 0 is unlimited"}})
+}

--- a/crates/apw-cli/tests/cli.rs
+++ b/crates/apw-cli/tests/cli.rs
@@ -1,0 +1,214 @@
+use std::process::{Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+use apw_cli::args::Cli;
+use apw_cli::{InputTarget, MAX_INPUT_BYTES, read_targets, resolve_targets};
+use apw_core::catalog::Catalog;
+use clap::Parser;
+use serde_json::{Value, json};
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_apw"))
+        .args(args)
+        .output()
+        .unwrap()
+}
+fn result(output: &Output) -> Value {
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.stderr.is_empty());
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn offline_discovery_and_search_work_from_an_unrelated_directory() {
+    let output = Command::new(env!("CARGO_BIN_EXE_apw"))
+        .arg("regions")
+        .current_dir(std::env::temp_dir())
+        .output()
+        .unwrap();
+    let regions = result(&output);
+    assert_eq!(regions["regions"].as_array().unwrap().len(), 7);
+    let stores = result(&run(&["stores", "--locale", "zh_CN", "--search", "r359"]));
+    assert_eq!(stores["stores"].as_array().unwrap().len(), 1);
+    assert_eq!(stores["stores"][0]["number"], "R359");
+    let products = result(&run(&[
+        "products",
+        "--locale",
+        "zh_CN",
+        "--category",
+        "iphone",
+        "--search",
+        "512",
+    ]));
+    assert_eq!(products["source"], "embedded");
+    assert!(!products["products"].as_array().unwrap().is_empty());
+    assert!(
+        products["products"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|p| p["category"] == "iphone")
+    );
+}
+
+#[test]
+fn schema_is_machine_readable_and_matches_discovered_commands() {
+    let schema = result(&run(&["schema"]));
+    assert_eq!(schema["schemaVersion"], 1);
+    assert_eq!(
+        schema["dataSchema"]["$defs"]["inputTarget"]["properties"]["locale"]["enum"]
+            .as_array()
+            .unwrap()
+            .len(),
+        7
+    );
+    for command in ["regions", "stores", "products", "check", "watch", "schema"] {
+        assert!(
+            schema["commands"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|c| c["name"] == command)
+        );
+    }
+}
+
+#[test]
+fn invalid_arguments_have_json_stderr_and_empty_stdout() {
+    for args in [
+        vec!["check"],
+        vec!["check", "--locale", "zh_CN", "--store", "R359"],
+        vec!["check", "--targets", "-", "--locale", "zh_CN"],
+        vec!["watch", "--interval", "1"],
+        vec!["check", "--timeout", "0"],
+        vec!["products", "--refresh"],
+        vec!["stores", "--locale", "de_DE"],
+        vec!["check", "--targets", "/apw-nonexistent-targets.json"],
+        vec!["invalid-command"],
+    ] {
+        let output = run(&args);
+        assert_eq!(output.status.code(), Some(2), "{args:?}: {output:?}");
+        assert!(output.stdout.is_empty(), "{args:?}");
+        let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+        assert_eq!(error["error"]["exitCode"], 2);
+    }
+}
+
+#[test]
+fn help_and_version_are_successful_text_exceptions() {
+    for args in [vec!["--help"], vec!["check", "--help"], vec!["--version"]] {
+        let output = run(&args);
+        assert!(output.status.success());
+        assert!(output.stderr.is_empty());
+        assert!(!output.stdout.is_empty());
+    }
+}
+
+#[test]
+fn repeated_flags_and_explicit_unlimited_watch_are_accepted() {
+    assert!(
+        Cli::try_parse_from([
+            "apw",
+            "watch",
+            "--locale",
+            "zh_CN",
+            "--store",
+            "R359",
+            "--store",
+            "R683",
+            "--part",
+            "MWUC3CH/A",
+            "--part",
+            "MWUD3CH/A",
+            "--timeout",
+            "0"
+        ])
+        .is_ok()
+    );
+}
+
+fn input(value: Value) -> InputTarget {
+    serde_json::from_value(value).unwrap()
+}
+
+#[test]
+fn exact_ids_are_validated_but_new_skus_are_not_rejected_by_stale_catalog() {
+    let catalog = Catalog::new();
+    let new =
+        || input(json!({"locale":"zh_CN", "storeNumber":"R999999", "partNumber":"NEW123CH/A"}));
+    let targets = resolve_targets(vec![new(), new()], &catalog).unwrap();
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].product_name, "NEW123CH/A");
+    assert_eq!(targets[0].store_title, "R999999");
+    for bad in [
+        json!({"locale":"de_DE", "storeNumber":"R359", "partNumber":"MWUC3CH/A"}),
+        json!({"locale":"zh_CN", "storeNumber":"上海", "partNumber":"MWUC3CH/A"}),
+        json!({"locale":"zh_CN", "storeNumber":"R359", "partNumber":"a|b"}),
+        json!({"locale":"zh_CN", "storeNumber":"R359", "partNumber":"/A"}),
+        json!({"locale":"zh_CN", "storeNumber":"R359", "partNumber":"A//B"}),
+        json!({"locale":"zh_CN", "storeNumber":"R359", "partNumber":""}),
+    ] {
+        assert_eq!(
+            resolve_targets(vec![input(bad)], &catalog)
+                .unwrap_err()
+                .exit_code,
+            2
+        );
+    }
+    assert!(resolve_targets(Vec::new(), &catalog).is_err());
+    assert!(resolve_targets((0..257).map(|_| new()).collect(), &catalog).is_err());
+}
+
+#[tokio::test]
+async fn json_input_rejects_typos_and_oversized_documents() {
+    assert!(
+        read_targets(&br#"[{"locale":"zh_CN","storeNumber":"R359","partNumer":"MWUC3CH/A"}]"#[..])
+            .await
+            .is_err()
+    );
+    let bytes = vec![b' '; MAX_INPUT_BYTES as usize + 1];
+    assert_eq!(
+        read_targets(bytes.as_slice()).await.unwrap_err().exit_code,
+        2
+    );
+    let targets =
+        read_targets(&br#"[{"locale":"zh_CN","storeNumber":"R359","partNumber":"MWUC3CH/A"}]"#[..])
+            .await
+            .unwrap();
+    assert_eq!(targets.len(), 1);
+}
+
+#[test]
+fn unclosed_stdin_does_not_defeat_process_deadline() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_apw"))
+        .args(["check", "--targets", "-", "--timeout", "1"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    // Keep the pipe open and send no input. This must not reach Apple.
+    let input = child.stdin.take().unwrap();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if child.try_wait().unwrap().is_some() {
+            break;
+        }
+        if Instant::now() > deadline {
+            child.kill().unwrap();
+            let _ = child.wait();
+            panic!("CLI did not honor deadline while reading stdin");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    drop(input);
+    let output = child.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(4));
+    assert!(output.stdout.is_empty());
+    let error: Value = serde_json::from_slice(&output.stderr).unwrap();
+    assert_eq!(error["error"]["kind"], "timeout");
+}

--- a/crates/apw-cli/tests/monitor.rs
+++ b/crates/apw-cli/tests/monitor.rs
@@ -1,0 +1,330 @@
+use std::collections::BTreeMap;
+use std::future::pending;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use apw_cli::{Mode, bounded, monitor};
+use apw_core::apple::{ApiError, Fetcher, PartStatus, StoreAvailability};
+use apw_core::model::{Availability, Region, Target};
+use apw_core::watcher::WatcherConfig;
+use serde_json::Value;
+
+type Reply = dyn Fn(usize, &str, &[String]) -> Result<StoreAvailability, ApiError> + Send + Sync;
+#[derive(Clone)]
+struct Fake {
+    calls: Arc<AtomicUsize>,
+    reply: Arc<Reply>,
+}
+impl Fake {
+    fn new(
+        reply: impl Fn(usize, &str, &[String]) -> Result<StoreAvailability, ApiError>
+        + Send
+        + Sync
+        + 'static,
+    ) -> Self {
+        Self {
+            calls: Arc::new(AtomicUsize::new(0)),
+            reply: Arc::new(reply),
+        }
+    }
+}
+impl Fetcher for Fake {
+    async fn pickup_message(
+        &self,
+        _: &'static Region,
+        store: &str,
+        parts: &[String],
+    ) -> Result<StoreAvailability, ApiError> {
+        (self.reply)(self.calls.fetch_add(1, Ordering::SeqCst), store, parts)
+    }
+}
+fn response(store: &str, parts: &[String], availability: Availability) -> StoreAvailability {
+    StoreAvailability {
+        store_number: store.into(),
+        store_name: store.into(),
+        parts: parts
+            .iter()
+            .map(|p| {
+                (
+                    p.clone(),
+                    PartStatus {
+                        part_number: p.clone(),
+                        availability: availability.clone(),
+                        product_title: None,
+                        pickup_display: String::new(),
+                    },
+                )
+            })
+            .collect::<BTreeMap<_, _>>(),
+    }
+}
+fn target(part: &str) -> Target {
+    Target {
+        locale: "zh_CN".into(),
+        store_number: "R359".into(),
+        store_title: "上海-南京东路".into(),
+        part_number: part.into(),
+        product_name: part.into(),
+    }
+}
+fn config() -> WatcherConfig {
+    WatcherConfig {
+        interval: Duration::from_secs(1),
+        jitter: 0.0,
+        ..WatcherConfig::default()
+    }
+}
+fn lines(out: &[u8]) -> Vec<Value> {
+    String::from_utf8_lossy(out)
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("JSON line"))
+        .collect()
+}
+
+#[tokio::test]
+async fn out_of_stock_is_success_and_check_performs_one_cycle() {
+    let fake = Fake::new(|_, store, parts| Ok(response(store, parts, Availability::OutOfStock)));
+    let mut out = Vec::new();
+    let code = monitor(
+        fake.clone(),
+        vec![target("MWUC3CH/A")],
+        config(),
+        Mode::Check,
+        &mut out,
+    )
+    .await
+    .unwrap();
+    assert_eq!(code, 0);
+    assert_eq!(fake.calls.load(Ordering::SeqCst), 1);
+    let rows = lines(&out);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["healthy"], true);
+    assert_eq!(rows[0]["anyInStock"], false);
+    assert_eq!(
+        rows[0]["snapshot"][0]["availability"]["kind"],
+        "out_of_stock"
+    );
+    assert!(rows[0]["snapshot"][0]["lastCheckedMs"].is_u64());
+}
+
+#[tokio::test]
+async fn blocked_check_is_unknown_with_reason_and_nonzero_exit() {
+    let fake = Fake::new(|_, _, _| Err(ApiError::Blocked("HTTP 541".into())));
+    let mut out = Vec::new();
+    let code = monitor(
+        fake,
+        vec![target("MWUC3CH/A")],
+        config(),
+        Mode::Check,
+        &mut out,
+    )
+    .await
+    .unwrap();
+    assert_eq!(code, 3);
+    let result = &lines(&out)[0];
+    assert_eq!(result["healthy"], false);
+    assert_eq!(
+        result["snapshot"][0]["availability"],
+        serde_json::json!({"kind": "unknown", "reason": "blocked", "detail": "HTTP 541"})
+    );
+}
+
+#[tokio::test]
+async fn missing_sku_does_not_erase_other_confirmed_stock() {
+    let fake = Fake::new(|_, store, parts| Ok(response(store, &parts[..1], Availability::InStock)));
+    let mut out = Vec::new();
+    let code = monitor(
+        fake,
+        vec![target("AAAA1CH/A"), target("BBBB1CH/A")],
+        config(),
+        Mode::Check,
+        &mut out,
+    )
+    .await
+    .unwrap();
+    assert_eq!(code, 3);
+    let result = &lines(&out)[0];
+    assert_eq!(result["anyInStock"], true);
+    assert_eq!(result["snapshot"][0]["availability"]["kind"], "in_stock");
+    assert_eq!(
+        result["snapshot"][1]["availability"]["reason"],
+        "schema_drift"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn continuous_stock_is_not_reannounced_but_stock_return_is() {
+    let fake = Fake::new(|n, store, parts| {
+        Ok(response(
+            store,
+            parts,
+            if n == 1 {
+                Availability::OutOfStock
+            } else {
+                Availability::InStock
+            },
+        ))
+    });
+    let mut out = Vec::new();
+    let error = bounded(
+        monitor(
+            fake,
+            vec![target("MWUC3CH/A")],
+            config(),
+            Mode::Watch {
+                until_in_stock: false,
+            },
+            &mut out,
+        ),
+        4,
+        pending(),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(error.exit_code, 4);
+    let rows = lines(&out);
+    assert_eq!(
+        rows.iter()
+            .filter(|r| r["event"]["type"] == "inStock")
+            .count(),
+        2
+    );
+    assert!(
+        rows.iter()
+            .filter(|r| r["event"]["type"] == "cycleComplete")
+            .count()
+            >= 3
+    );
+    assert!(
+        rows.iter()
+            .all(|r| r["schemaVersion"] == 1 && r["command"] == "watch")
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn until_in_stock_waits_past_negative_result_then_exits() {
+    let fake = Fake::new(|n, store, parts| {
+        Ok(response(
+            store,
+            parts,
+            if n == 0 {
+                Availability::OutOfStock
+            } else {
+                Availability::InStock
+            },
+        ))
+    });
+    let mut out = Vec::new();
+    let code = bounded(
+        monitor(
+            fake.clone(),
+            vec![target("MWUC3CH/A")],
+            config(),
+            Mode::Watch {
+                until_in_stock: true,
+            },
+            &mut out,
+        ),
+        10,
+        pending(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(code, 0);
+    assert_eq!(fake.calls.load(Ordering::SeqCst), 2);
+    assert_eq!(lines(&out).last().unwrap()["event"]["type"], "inStock");
+}
+
+#[derive(Clone)]
+struct Hanging(Arc<AtomicUsize>);
+struct InFlight(Arc<AtomicUsize>);
+impl Drop for InFlight {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+impl Fetcher for Hanging {
+    async fn pickup_message(
+        &self,
+        _: &'static Region,
+        _: &str,
+        _: &[String],
+    ) -> Result<StoreAvailability, ApiError> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        let _guard = InFlight(self.0.clone());
+        pending().await
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn deadline_cancels_inflight_query_and_emits_no_fabricated_result() {
+    let active = Arc::new(AtomicUsize::new(0));
+    let mut out = Vec::new();
+    let error = bounded(
+        monitor(
+            Hanging(active.clone()),
+            vec![target("MWUC3CH/A")],
+            config(),
+            Mode::Check,
+            &mut out,
+        ),
+        1,
+        pending(),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(error.exit_code, 4);
+    assert!(out.is_empty());
+    tokio::time::sleep(Duration::from_millis(1)).await;
+    assert_eq!(active.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn shutdown_cancels_unlimited_watch() {
+    let active = Arc::new(AtomicUsize::new(0));
+    let mut out = Vec::new();
+    let shutdown = async {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        Ok(143)
+    };
+    let error = bounded(
+        monitor(
+            Hanging(active.clone()),
+            vec![target("MWUC3CH/A")],
+            config(),
+            Mode::Watch {
+                until_in_stock: false,
+            },
+            &mut out,
+        ),
+        0,
+        shutdown,
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(error.exit_code, 143);
+    tokio::time::sleep(Duration::from_millis(1)).await;
+    assert_eq!(active.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn broken_output_pipe_stops_the_engine() {
+    use tokio::io::AsyncWriteExt;
+    let (mut output, reader) = tokio::io::duplex(128);
+    drop(reader);
+    let fake = Fake::new(|_, store, parts| Ok(response(store, parts, Availability::InStock)));
+    let error = monitor(
+        fake,
+        vec![target("MWUC3CH/A")],
+        config(),
+        Mode::Watch {
+            until_in_stock: false,
+        },
+        &mut output,
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(error.exit_code, 141);
+    let _ = output.shutdown().await;
+}

--- a/crates/apw-core/Cargo.toml
+++ b/crates/apw-core/Cargo.toml
@@ -14,13 +14,16 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 rand.workspace = true
-rodio.workspace = true
+rodio = { workspace = true, optional = true }
 dirs.workspace = true
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync", "test-util"] }
 
 [features]
+default = ["notifications"]
+# CLI 只消费库存事件，不需要推送或音频设备依赖。
+notifications = ["dep:rodio"]
 # live 打开后才会跑针对 Apple 真实接口的契约测试：
 #   cargo test -p apw-core --features live -- --ignored --nocapture
 # 默认关闭，免得每次 cargo test 都去打扰 Apple 的服务。

--- a/crates/apw-core/src/lib.rs
+++ b/crates/apw-core/src/lib.rs
@@ -23,5 +23,6 @@ pub mod apple_catalog;
 pub mod catalog;
 pub mod config;
 pub mod model;
+#[cfg(feature = "notifications")]
 pub mod notify;
 pub mod watcher;

--- a/crates/apw-core/tests/notify.rs
+++ b/crates/apw-core/tests/notify.rs
@@ -4,6 +4,8 @@
 //! 断言它收到的**原始**请求行；提示音只测不需要声卡的那几条路径，真的要响一声
 //! 的用例挂了 `#[ignore]`，手动跑。
 
+#![cfg(feature = "notifications")]
+
 use std::io::{BufRead, BufReader, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,141 @@
+# APW CLI 与 agent skill
+
+`apw` 是独立的 Rust 命令行程序，复用桌面版的 `apw-core`，无需运行 Tauri、浏览器或音频设备。支持 macOS、Windows、Linux；发布包与桌面安装包分开。库存判定、按门店合并请求、失败退避和到货去重使用同一套核心代码。
+
+## 构建和安装
+
+在**源码仓库**根目录使用 stable Rust（最低版本见根目录 `Cargo.toml`）：
+
+```bash
+cargo build --release --locked -p apw-cli
+./target/release/apw --version
+./target/release/apw regions
+```
+
+Windows 的可执行文件是 `target/release/apw.exe`。仅构建 CLI 不需要 Node、pnpm、WebKit、GTK 或 ALSA。
+
+在源码仓库中安装到 Cargo 的 bin 目录（通常是 `~/.cargo/bin`）：
+
+```bash
+cargo install --path crates/apw-cli --locked
+```
+
+预编译包解压后可直接运行其中的 `apw` / `apw.exe`，也可把它放到 PATH 中。包名带版本和 Rust target triple；Linux GNU 包在 Ubuntu 24.04 构建，运行环境需要兼容的 glibc。选择与操作系统及架构匹配的包。
+
+配套 skill 位于 `skills/apple-pickup-watcher/`。将整个目录复制到 agent 的技能目录；Codex 的默认位置是 `${CODEX_HOME:-$HOME/.codex}/skills/apple-pickup-watcher/`。已有同名 skill 时先比较内容，不要直接覆盖本地定制。新会话中可以通过 `$apple-pickup-watcher` 调用。其他支持 `SKILL.md` 的 agent 可导入同一目录；agent 还需要 Shell 工具及可访问的 `apw` 可执行文件。
+
+## 命令
+
+所有业务命令默认输出 JSON；`watch` 逐行输出 NDJSON。无需 `--json`。`--help` 和 `--version` 是文本输出。
+
+```bash
+apw regions
+apw stores --locale zh_CN --search 上海
+apw products --locale zh_CN --category iphone --search '512GB'
+apw products --locale zh_CN --category iphone --refresh --timeout 120
+apw schema
+```
+
+地区标识来自 `regions[].locale`；门店编号来自 `stores[].number`；SKU 来自 `products[].partNumber`。品类为 `iphone`、`ipad`、`mac`、`watch`。`--search` 不区分大小写，也支持中文。目录默认使用内置快照；目录非空不代表商品有货。
+
+`--refresh` 必须指定品类，仅在本次调用内刷新该品类。失败页保留内置数据，并以退出码 3、`refreshComplete: false` 和 `warning` 明示刷新不完整。超时以退出码 4 和 stderr 报错，不返回一个看似完整的目录。新 SKU 可以直接传入查询，不要求它存在于内置快照中。
+
+### 单次查询
+
+```bash
+apw check --locale zh_CN --store R359 --part 'MWUC3CH/A' --timeout 60
+```
+
+门店及 SKU 仅为示例，按实际需求从目录选择。返回形状如下（示例状态不代表实时库存）：
+
+```json
+{
+  "schemaVersion": 1,
+  "command": "check",
+  "healthy": true,
+  "anyInStock": false,
+  "snapshot": [{
+    "target": {
+      "locale": "zh_CN", "storeNumber": "R359", "storeTitle": "上海-南京东路",
+      "partNumber": "MWUC3CH/A", "productName": "示例商品"
+    },
+    "availability": {"kind": "out_of_stock"},
+    "lastCheckedMs": 1789000000000,
+    "consecutiveFailures": 0
+  }]
+}
+```
+
+`check` 执行一轮查询后退出。`healthy` 表示所有目标都取得明确结果；`anyInStock` 表示其中至少一项确认有货。HTTP 541 等失败返回 `{"kind":"unknown","reason":"blocked","detail":"…"}`，不会转成无货；一部分目标未知时退出 3，仍保留其他目标的已知结果。
+
+### 批量输入
+
+重复 `--store` 与 `--part` 可查询它们的所有组合。需要跨地区或只查指定组合时，使用目标数组：
+
+```json
+[
+  {"locale":"zh_CN","storeNumber":"R359","partNumber":"MWUC3CH/A"},
+  {"locale":"zh_CN","storeNumber":"R683","partNumber":"MWUD3CH/A"}
+]
+```
+
+```bash
+apw check --targets targets.json
+apw check --targets - < targets.json
+```
+
+最多 256 个输入目标、1 MiB；同一 `locale / storeNumber / partNumber` 去重。`storeTitle` 与 `productName` 可选，缺省时由目录补齐，目录找不到则显示编号。未知字段和错误的编号格式会报错。`--targets` 与 `--locale / --store / --part` 互斥。CLI 不读取或修改桌面版设置，不执行配置迁移。
+
+### 持续监控
+
+```bash
+apw watch --targets targets.json --interval 30 --timeout 300
+apw watch --targets targets.json --until-in-stock --timeout 300
+```
+
+事件封装为 `{"schemaVersion":1,"command":"watch","event":{...}}`。事件类型在 `event.type`：
+
+| 类型 | 含义 |
+| --- | --- |
+| `stateChanged` | `state` 中的目标状态变化；`not_yet_checked` 表示尚未查询 |
+| `inStock` | `state` 中的目标确认到货；持续有货不重复提醒 |
+| `cycleComplete` | `healthy` 与完整 `snapshot`，用来对齐全部状态和检查时间 |
+| `trouble` | `reason` 与可选 `advice`，说明监控故障 |
+| `runStateChanged` | `running`，说明引擎启停 |
+
+`--until-in-stock` 在任一目标到货时退出 0。默认监控 300 秒；期限届满退出 4，即使此前有健康查询，也不代表等待条件已满足。期间的库存行只是各自时间点的观察结果。默认间隔 30 秒、最低 5 秒，抖动和失败退避仍生效。限速和去重属于单个进程；避免启动多个重复的 watcher。
+
+明确需要长期运行时可用 `--timeout 0`，由终端或进程管理器保持进程。Ctrl-C / SIGTERM 会取消在途查询。消费者关闭输出管道时退出 141。命令退出后监控结束；CLI 本身不弹窗、播放声音、发推送、打开网页或购买商品，agent 可根据用户请求处理 `inStock` 事件。
+
+### 退出码与错误
+
+| 退出码 | 含义 |
+| --- | --- |
+| 0 | 查询/目录成功，或等待条件满足；查询成功也可能是明确无货 |
+| 1 | 内部错误或 I/O 失败 |
+| 2 | 参数、目标文件或编号错误 |
+| 3 | 查询存在未知结果，或目录刷新不完整；仍需读取 stdout |
+| 4 | 整体超时，包括输入读取、请求和输出等待 |
+| 130 / 143 | Ctrl-C / SIGTERM 中断 |
+| 141 | 输出管道关闭 |
+
+不可继续的错误输出到 stderr：
+
+```json
+{"schemaVersion":1,"error":{"kind":"timeout","message":"Deadline of 60 seconds exceeded","exitCode":4}}
+```
+
+超时或中断可能没有完整结果，不能推断为无货。`watch` 的最后一个事件可能不是 `runStateChanged`；以进程退出码判断命令如何结束。不要依赖中文错误文案做逻辑判断，使用状态、`reason`、`error.kind` 和退出码。
+
+`apw schema` 提供运行版本、实际命令参数、退出码及 JSON Schema `$defs`（`targets`、`availability`、`targetState`、`check`、`watch`、`error`）。扩展字段可在同一 schemaVersion 内增加；破坏字段语义的改动必须升级 schemaVersion。
+
+## 验证与打包
+
+```bash
+cargo test --locked -p apw-cli
+cargo test --locked -p apw-core --no-default-features
+cargo clippy --locked -p apw-cli --all-targets -- -D warnings
+python3 scripts/package-cli.py --binary target/release/apw --target aarch64-apple-darwin
+```
+
+日常测试保持离线。CLI 测试用真实核心引擎和模拟 Fetcher 验证库存错误、部分结果、去重及取消，并用真实子进程验证接口输出与 stdin 超时。`.github/workflows/cli.yml` 独立验证四个平台、构建二进制并打包 CLI、skill、文档和许可，上传 Actions artifacts；不依赖桌面构建，也不自动发布公开 Release。

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -1,0 +1,65 @@
+# 桌面版指南
+
+[返回 README](../README.md) · [CLI / agent](cli.md)
+
+## 安装
+
+从 [Releases](https://github.com/ENCHIGO/apple-pickup-watcher/releases) 选择系统和架构对应的安装包。
+
+- **macOS**：区分 Apple Silicon 和 Intel。应用未经过 Apple 公证，放入「应用程序」后，如果被系统拦下，可以对这个应用执行 `xattr -cr "/Applications/Apple Pickup Watcher.app"`。
+- **Windows**：安装包未签名，SmartScreen 可能提示「Windows 已保护你的电脑」。确认下载来源后，选择「更多信息」→「仍要运行」。
+- **Linux**：按 Release 提供的格式安装。AppImage 需要可执行权限：`chmod +x 下载的文件.AppImage`。系统要求以对应 Release 说明为准。
+
+## 监控与提醒
+
+选择地区、品类、门店和型号，添加目标后点击「开始」。可以同时监控多个门店和商品。
+
+窗口关闭后应用会收进托盘，Rust 后台继续查询和提醒。真正退出需使用托盘菜单的「退出」。电脑需要联网并保持唤醒。
+
+默认查询间隔 30 秒，下限 5 秒；实际间隔还包括抖动和失败退避。持续有货不会每轮重复提醒；从无货或未知再次变成有货时重新提醒。暂停后再开始会重新启用提醒，下一次查询确认仍有货也会再次提醒。
+
+有货后会继续查询全部目标，表格的「最后检查」时间可用于确认是否还在轮询。每次开始到暂停期间，按设置最多自动打开一次购物袋；其他目标仍然提醒。添加商品、选择取货门店、结账和付款由用户在 Apple 官网完成。
+
+## 型号目录
+
+「从 Apple 官网更新型号列表」只刷新当前品类的已配置购买页；失败的页面保留旧数据并显示错误。新增购买页的机型可能需要先更新程序，不会自动发现所有新页面。内置快照中的商品不代表目前仍在售或有货。
+
+应用内更新会先提示，由用户决定是否安装。
+
+## Bark 推送
+
+安装 [Bark](https://github.com/Finb/Bark)，将它提供的完整设备地址填入「Bark 推送地址」，留空表示关闭。可保留自定义查询参数，例如：
+
+```text
+https://api.day.app/你的Key?group=库存&sound=alarm
+```
+
+点击「测试提醒」验证系统通知、声音和 Bark。推送失败会显示渠道错误，不会改变库存判定。分享日志时请隐去设备 key。
+
+## 配置文件
+
+| 平台 | 路径 |
+| --- | --- |
+| macOS | `~/Library/Application Support/apple-pickup-watcher/settings.v2.json` |
+| Windows | `%APPDATA%\apple-pickup-watcher\settings.v2.json` |
+| Linux | `$XDG_CONFIG_HOME/apple-pickup-watcher/settings.v2.json`，默认 `~/.config/apple-pickup-watcher/settings.v2.json` |
+
+新版配置与 Go 版的 `settings.json` 分开。迁移只读旧文件；写入采用原子替换。遇到损坏配置会尝试留档并显示原因和位置，避免用默认配置覆盖旧内容。CLI 使用显式参数或目标文件，不写桌面版配置。
+
+## 常见问题
+
+### 未知、待查询和无货有什么区别？
+
+「待查询」表示还没有完成首次查询；「未知」表示没有取得明确结果，原因可能是拦截、限流、网络失败或响应结构变化；「无货」表示本次查询得到明确的不可取货结果。
+
+看到「监控当前不可信」时，检查具体目标的原因与最后查询时间。不能把未知或过期的结果当作当前无货。
+
+### HTTP 541，或浏览器正常但程序查询失败？
+
+程序将这类响应归为被拦截，不能据此判断库存。记录应用版本、地区、门店、SKU、错误和出现时间，可暂停后稍后重试，或按界面建议检查网络。持续失败时提交 [Issue](https://github.com/ENCHIGO/apple-pickup-watcher/issues)。
+
+浏览器与程序的会话和网络请求条件可能不同；单台机器查询成功，也不能证明其他网络上的问题已修复。
+
+### 和原项目有什么关系？
+
+本项目重写了 [apple-store-helper](https://github.com/hteen/apple-store-helper) 的客户端与界面，使用 `/shop/retail/pickup-message` 查询，并将失败保留为带原因的未知。项目同时保留离线回归与单独的真实接口契约测试。来源与修改说明见 [NOTICE](../NOTICE)。

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,77 @@
+# 开发与维护
+
+[返回 README](../README.md) · [CLI 构建与接口](cli.md)
+
+## 工具链与系统依赖
+
+使用 stable Rust，最低版本见根目录 [Cargo.toml](../Cargo.toml)。桌面前端使用 Node.js LTS 和 pnpm 9。
+
+桌面版的系统依赖以 [CI](../.github/workflows/ci.yml) 和 [Release 工作流](../.github/workflows/release.yml) 为准：macOS 需要 Xcode Command Line Tools；Windows 需要 Microsoft C++ 生成工具和 WebView2；Linux 需要 WebKitGTK、托盘和 ALSA 等开发库。Ubuntu 开发环境可使用 [scripts/codex-setup.sh](../scripts/codex-setup.sh)。
+
+CLI 单独构建不启用通知 feature，不需要桌面或音频依赖。
+
+## 开发与检查
+
+```bash
+pnpm install --frozen-lockfile
+pnpm tauri dev
+pnpm tauri build
+```
+
+按改动范围执行检查；完整日常检查与 CI 一致：
+
+```bash
+cargo fmt --all --check
+python3 crates/apw-core/data/generate.py --self-test
+python3 -m unittest discover -s scripts -p 'test_*.py'
+pnpm exec tsc --noEmit
+pnpm test
+pnpm exec vite build
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test
+```
+
+普通测试保持离线，不为 `cargo test` 添加 `--all-features` 或 `--features live`。Clippy 的 `--all-features` 只编译，不执行真实请求。
+
+## 代码结构
+
+| 目录 | 职责 |
+| --- | --- |
+| `crates/apw-core/` | 库存类型、Apple 客户端、目录、监控引擎、通知与配置 |
+| `crates/apw-cli/` | `apw` 命令、JSON/NDJSON 输出、目标输入与进程生命周期 |
+| `src-tauri/` | 桌面装配、IPC、托盘、系统通知与购物袋打开 |
+| `src/`、`tests/` | React 界面、前端状态及交互测试 |
+| `skills/apple-pickup-watcher/` | 配套 agent skill |
+| `site/` | 中英文项目介绍页，见 [站点维护说明](discoverability.md) |
+
+库存判定留在 `apw-core`，失败必须保留为带原因的 `Unknown`。通知失败不得改写库存；配置迁移不得修改旧文件，损坏配置不得被默认值覆盖。完整约定见 [AGENTS.md](../AGENTS.md)。
+
+## 真实接口与目录快照
+
+[CI](../.github/workflows/ci.yml) 的单独任务按天运行真实接口契约测试。需要手动验证时：
+
+```bash
+cargo test -p apw-core --features live --test live -- --nocapture --test-threads=1
+```
+
+该命令会访问 Apple，检查真实响应与 HTTP 协商。型号过期时更新测试目标，测试结果仅代表对应时间和网络下的观察。
+
+离线快照生成器不带 `--self-test` 时会联网并改写数据：
+
+```bash
+python3 crates/apw-core/data/generate.py
+```
+
+新增购买页或适配页面结构后再按需更新快照，检查是否存在抓取失败和缺页。
+
+## 提交与发布
+
+`main` 按仓库分支保护规则通过 PR 更新；当前要求 Linux 和 macOS 检查通过。规则以 GitHub 设置为准，不为普通发布关闭保护。
+
+桌面版本更新需同步 `Cargo.toml`、工作区 crate 的 `Cargo.lock` 版本、`package.json` 和 `src-tauri/tauri.conf.json`。`v*` 标签触发桌面打包并创建 Release 草稿，手动触发仅构建。所有平台产物就绪并核对后再发布草稿。
+
+桌面更新签名使用 `TAURI_SIGNING_PRIVATE_KEY` 和 `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` 两个仓库 Secret。缺少密钥时工作流按配置输出未签名安装包；应用内更新需要与内嵌公钥匹配的签名。私钥应离线备份，不提交到仓库。
+
+[CLI 工作流](../.github/workflows/cli.yml) 独立构建 macOS Apple Silicon / Intel、Windows x64 和 Linux x86_64，上传包含 CLI、skill、文档、许可及校验和的 Actions artifacts。它不自动创建公开 Release。
+
+发布后的版本分支由 [Release branches 工作流](../.github/workflows/release-branches.yml) 维护。站点部署与桌面发布彼此独立。

--- a/scripts/package-cli.py
+++ b/scripts/package-cli.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Package a built APW CLI with its agent skill, documentation and licenses."""
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import tarfile
+import tempfile
+import shutil
+import tomllib
+import zipfile
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--target", required=True, help="Rust target triple of the supplied binary")
+    parser.add_argument("--output", type=Path, default=Path("target/cli-dist"))
+    args = parser.parse_args()
+    if not re.fullmatch(r"[a-zA-Z0-9_-]+", args.target):
+        parser.error("invalid target triple")
+    if not args.binary.is_file():
+        parser.error(f"binary not found: {args.binary}")
+    root = Path(__file__).resolve().parents[1]
+    version = tomllib.loads((root / "Cargo.toml").read_text())["workspace"]["package"]["version"]
+    name = f"apw-cli-v{version}-{args.target}"
+    args.output.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="apw-cli-package-") as temporary:
+        package = Path(temporary) / name
+        package.mkdir()
+        binary_name = "apw.exe" if "windows" in args.target else "apw"
+        shutil.copy2(args.binary, package / binary_name)
+        (package / binary_name).chmod(0o755)
+        for filename in ("LICENSE", "NOTICE"):
+            shutil.copy2(root / filename, package / filename)
+        shutil.copy2(root / "docs/cli.md", package / "README.md")
+        shutil.copytree(root / "skills/apple-pickup-watcher", package / "skills/apple-pickup-watcher")
+        manifest = {"version": version, "target": args.target, "binary": binary_name,
+                    "sha256": hashlib.sha256(args.binary.read_bytes()).hexdigest(), "schemaVersion": 1}
+        (package / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+        if "windows" in args.target:
+            archive = args.output / f"{name}.zip"
+            with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
+                for path in sorted(package.rglob("*")):
+                    if path.is_file():
+                        bundle.write(path, path.relative_to(package.parent))
+        else:
+            archive = args.output / f"{name}.tar.gz"
+            with tarfile.open(archive, "w:gz") as bundle:
+                bundle.add(package, arcname=name)
+    checksum = hashlib.sha256(archive.read_bytes()).hexdigest()
+    archive.with_name(archive.name + ".sha256").write_text(f"{checksum}  {archive.name}\n")
+    print(archive.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/package-cli.py
+++ b/scripts/package-cli.py
@@ -24,7 +24,7 @@ def main():
     if not args.binary.is_file():
         parser.error(f"binary not found: {args.binary}")
     root = Path(__file__).resolve().parents[1]
-    version = tomllib.loads((root / "Cargo.toml").read_text())["workspace"]["package"]["version"]
+    version = tomllib.loads((root / "Cargo.toml").read_text(encoding="utf-8"))["workspace"]["package"]["version"]
     name = f"apw-cli-v{version}-{args.target}"
     args.output.mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory(prefix="apw-cli-package-") as temporary:
@@ -39,7 +39,7 @@ def main():
         shutil.copytree(root / "skills/apple-pickup-watcher", package / "skills/apple-pickup-watcher")
         manifest = {"version": version, "target": args.target, "binary": binary_name,
                     "sha256": hashlib.sha256(args.binary.read_bytes()).hexdigest(), "schemaVersion": 1}
-        (package / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+        (package / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
         if "windows" in args.target:
             archive = args.output / f"{name}.zip"
             with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as bundle:
@@ -51,7 +51,7 @@ def main():
             with tarfile.open(archive, "w:gz") as bundle:
                 bundle.add(package, arcname=name)
     checksum = hashlib.sha256(archive.read_bytes()).hexdigest()
-    archive.with_name(archive.name + ".sha256").write_text(f"{checksum}  {archive.name}\n")
+    archive.with_name(archive.name + ".sha256").write_text(f"{checksum}  {archive.name}\n", encoding="utf-8")
     print(archive.resolve())
 
 

--- a/scripts/test_package_cli.py
+++ b/scripts/test_package_cli.py
@@ -1,0 +1,60 @@
+"""Validate both package formats without needing cross-platform Rust binaries."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class PackageCliTests(unittest.TestCase):
+    def test_packages_use_utf8_and_include_binary_skill_and_matching_checksums(self):
+        for target, extension, binary_name in [
+            ("aarch64-apple-darwin", ".tar.gz", "apw"),
+            ("x86_64-pc-windows-msvc", ".zip", "apw.exe"),
+        ]:
+            with self.subTest(target=target), tempfile.TemporaryDirectory() as temporary:
+                work = Path(temporary)
+                binary = work / "fixture.bin"
+                payload = b"APW packaging fixture\x00\xff"
+                binary.write_bytes(payload)
+                # Unix: force ASCII. Windows: retain the system legacy code page.
+                # Cargo.toml contains Chinese comments and must be read as UTF-8.
+                environment = {**os.environ, "LC_ALL": "C", "PYTHONUTF8": "0", "PYTHONCOERCECLOCALE": "0"}
+                result = subprocess.run(
+                    [sys.executable, str(ROOT / "scripts/package-cli.py"),
+                     "--binary", str(binary), "--target", target, "--output", str(work / "out")],
+                    env=environment, capture_output=True, timeout=30,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr.decode("utf-8", errors="replace"))
+                archive = next((work / "out").glob("*" + extension))
+                checksum = archive.with_name(archive.name + ".sha256").read_text(encoding="utf-8").split()[0]
+                self.assertEqual(checksum, hashlib.sha256(archive.read_bytes()).hexdigest())
+                if extension == ".zip":
+                    with zipfile.ZipFile(archive) as bundle:
+                        files = {name.split("/", 1)[1]: bundle.read(name) for name in bundle.namelist()}
+                else:
+                    with tarfile.open(archive) as bundle:
+                        files = {member.name.split("/", 1)[1]: bundle.extractfile(member).read()
+                                 for member in bundle.getmembers() if member.isfile()}
+                self.assertEqual(files[binary_name], payload)
+                manifest = json.loads(files["manifest.json"])
+                self.assertEqual(manifest["target"], target)
+                self.assertEqual(manifest["binary"], binary_name)
+                self.assertEqual(manifest["sha256"], hashlib.sha256(payload).hexdigest())
+                for filename in ["LICENSE", "NOTICE", "README.md",
+                                 "skills/apple-pickup-watcher/SKILL.md",
+                                 "skills/apple-pickup-watcher/agents/openai.yaml"]:
+                    self.assertTrue(files[filename], filename)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/apple-pickup-watcher/SKILL.md
+++ b/skills/apple-pickup-watcher/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: apple-pickup-watcher
+description: Query Apple Retail pickup availability and monitor specified stores and SKUs with the apw CLI. Use when the user asks about Apple in-store stock, available pickup stores, or a bounded stock watch.
+---
+
+# Apple Pickup Watcher
+
+Use `apw` for inventory queries. It runs without the desktop application and emits JSON. It does not add to a bag, place orders, or send notifications itself.
+
+## Locate and discover
+
+Use `apw --version` and `apw schema` to identify the installed interface. If `apw` is absent, use an explicitly supplied executable path; in a source checkout the build is `cargo build --release --locked -p apw-cli` and the executable is `target/release/apw` (`apw.exe` on Windows). If neither binary nor source checkout is available, explain that the CLI must be installed; do not invent a download URL.
+
+`apw schema` returns the supported flags, exit codes, limits and JSON Schema definitions. This skill covers `schemaVersion: 1`; inspect a different version's contract before relying on field names.
+
+Resolve the user's request through the catalog:
+
+```bash
+apw regions
+apw stores --locale zh_CN --search 上海
+apw products --locale zh_CN --category iphone --search '512GB'
+```
+
+Use the returned `locale`, store `number`, and product `partNumber`. A store name or product family is not an identifier. If several variants fit and the user has not requested all of them, clarify the relevant capacity/color/model or store choice. Do not treat the example identifiers below as the user's selection.
+
+Catalog commands use embedded snapshots by default; they are not live stock checks. When current models are needed, use `apw products --locale zh_CN --category iphone --refresh --timeout 120`. An incomplete refresh exits 3 and includes `warning` and fallback data; describe the data as incomplete. Refreshed data lives only in that invocation, but its returned SKUs can be passed to `check` directly.
+
+## Query or watch
+
+```bash
+apw check --locale zh_CN --store R359 --part 'MWUC3CH/A' --timeout 60
+apw watch --locale zh_CN --store R359 --part 'MWUC3CH/A' \
+  --interval 30 --until-in-stock --timeout 300
+```
+
+`check` completes one cycle. For explicit target pairs or multiple regions, use a JSON array with `--targets FILE` or `--targets -` (stdin):
+
+```json
+[
+  {"locale":"zh_CN","storeNumber":"R359","partNumber":"MWUC3CH/A"}
+]
+```
+
+Up to 256 targets / 1 MiB are accepted. Repeated `--store` and `--part` flags query every store/part combination; use the JSON array when only particular pairs are intended. `--targets` is exclusive with those flags and `--locale`.
+
+Prefer one bounded `watch` process for repeated checks so the engine can share connections, apply backoff, and deduplicate arrival events. The default interval is 30 seconds (minimum 5). Keep the host tool's execution deadline longer than the CLI's deadline. An unlimited `--timeout 0` watch requires a host that can retain the process and a user request for ongoing monitoring. Ending a foreground command or receiving a timeout ends monitoring; do not claim it will continue or notify later.
+
+## Interpret results
+
+- `check.snapshot[]` contains the target, `availability`, `lastCheckedMs` (Unix milliseconds), and consecutive failure count. `anyInStock` means at least one target is confirmed; `healthy` means every target has a known result.
+- `availability.kind`: `in_stock` confirms pickup availability; `out_of_stock` is a confirmed negative. `unknown` must retain its `reason` and relevant detail. `not_yet_checked` means pending. A timeout or missing result is not evidence of no stock.
+- `watch` emits one JSON object per line; the event is under `event`. `inStock` is an arrival notification; `cycleComplete.snapshot` is the complete cycle view. Continuous stock is not repeatedly announced. `--until-in-stock` exits on **any** target's first confirmed arrival; it does not wait for all targets.
+- Exit 0 means a successful query (including no stock), or a satisfied watch condition. Exit 3 means unknown stock or incomplete refresh; parse stdout even on this exit, because other rows may be known. Exit 4 means the overall deadline elapsed; earlier events are historical observations. Exit 2 is invalid input, 1 is an internal/I/O error, 130/143 is interruption, and 141 means the output consumer closed its pipe.
+- stdout contains JSON/NDJSON; stderr contains structured fatal errors. `--help` and `--version` are text exceptions. Do not hide nonzero exits with `|| true`, discard partial stdout, or translate request errors into no stock.
+
+Report the exact region/store/model, observation time, and any unknown or incomplete result. A fresh successful check demonstrates this invocation's result, not reliability on every network. HTTP 541 should be reported as blocked; avoid rapid retries or concurrent duplicate watchers. Let the user's requested workflow determine whether an arrival is simply reported or passed to an already authorized notification channel.

--- a/skills/apple-pickup-watcher/agents/openai.yaml
+++ b/skills/apple-pickup-watcher/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Apple Pickup Watcher"
+  short_description: "Query Apple pickup stock and run bounded watches"
+  default_prompt: "Use $apple-pickup-watcher to check pickup availability for my chosen Apple product and stores."


### PR DESCRIPTION
新增独立 `apw` CLI 和配套 `apple-pickup-watcher` skill，让有 Shell 工具的 agent 直接查询库存、批量查询指定目标、读取持续监控事件。CLI 复用 `apw-core` 的库存判定、退避和到货去重；单独构建关闭通知依赖，无需 Tauri 或音频设备。

README 从 462 行缩至 95 行，首页保留桌面版下载、CLI 安装、skill 接入和查询示例。配置、排障及维护内容整理到 `docs/desktop.md`、`docs/cli.md` 和 `docs/development.md`，保留项目主页与原有安装锚点。

- 普通命令输出 JSON，监控输出 NDJSON；提供 `schema`、明确退出码、整体超时和信号取消。
- 请求失败和缺失结果保持带原因的 Unknown，部分失败仍保留其他目标的已知结果。
- 新增四平台 CLI 工作流，打包二进制、skill、文档、许可和 SHA-256 校验文件为 Actions artifacts，并运行发布二进制验证 schema 输出。打包脚本显式使用 UTF-8，回归测试覆盖非 UTF-8 系统环境下的 tar.gz 和 zip 打包。

验证：基于当前 main，175 项 Rust 测试通过，1 项需要声卡的测试按原配置忽略；11 项前端测试、12 项维护脚本测试、类型检查、Vite 构建、fmt、Clippy、快照自检、skill 校验以及中英文站点构建/链接检查通过。CLI 的 16 项离线测试覆盖状态判定、部分结果、到货去重、输入边界、超时和取消。CLI 初版还完成了本机发布包解压验证和一次真实库存查询；跨平台产物由本 PR 的远端 CI 验证。
