### PR TITLE
发布 v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "apw-app"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "apw-core",
  "reqwest 0.12.28",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "apw-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "apw-core",
  "clap",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "apw-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "dirs",
  "rand 0.9.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/apw-core", "crates/apw-cli", "src-tauri"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.90"
 license = "GPL-3.0-or-later"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apple-pickup-watcher",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Apple Pickup Watcher",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "identifier": "io.github.enchigo.apple-pickup-watcher",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
版本号提升到 0.4.1：Cargo.toml、Cargo.lock、package.json、src-tauri/tauri.conf.json。

本版包含 #25（Apple Watch 表壳随同页表带一起查询，修复整品类查不出结果；离线快照重新生成；移除已下架的 iphone-17-pro 购买页；展示名修正）和 #23（README 与站点更新）。合并后打 v0.4.1 标签触发打包。